### PR TITLE
Advanced diagnostics and linting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Verbose console.log in definition provider polluting test and server output
 
 ### Added
+- Advanced diagnostics and linting: missing semicolons, duplicate declarations, undefined variables, unused variables, type mismatches (#6)
+- Semantic analysis powered by AST parser symbols for deeper code inspection (#6)
+- Quick fixes for semantic diagnostics: insert semicolon, remove duplicate declaration, remove unused variable (#6)
+- Levenshtein-based fuzzy matching for "did you mean?" suggestions on undefined identifiers (#6)
 - Code formatting (Shift+Alt+F): keyword casing, indentation, operator spacing, VAR block alignment, trailing whitespace removal (#29)
 - Format Selection support for partial document formatting (#29)
 - Configurable formatting settings: keywordCase, insertSpacesAroundOperators, alignVarDeclarations, trimTrailingWhitespace, insertFinalNewline (#29)
@@ -19,6 +23,7 @@
 - 31 unit tests for code action provider (151 → 182 total) (#26)
 - 58 unit tests for rename provider (182 → 240 total) (#28)
 - 67 unit tests for formatting provider (240 → 307 total) (#29)
+- 46 unit tests for Phase 2 semantic diagnostics, levenshtein/fuzzy matching, and code actions (307 → 353 total) (#6)
 - Clean build steps for compile and webpack scripts
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Professional **Structured Text (IEC 61131-3)** development environment for **PLC
 ## Key Features
 
 - **Code Formatting**: Format Document (Shift+Alt+F), Format Selection, configurable keyword casing, operator spacing, VAR alignment
-- **Real-time Diagnostics**: Errors and warnings as you type — Problems panel, red squiggly underlines, hover tooltips
-- **Code Actions & Quick Fixes**: One-click fixes for missing END blocks, unclosed strings, unmatched parentheses
+- **Real-time Diagnostics**: Errors and warnings as you type — missing semicolons, type mismatches, undefined/unused variables, unmatched blocks
+- **Code Actions & Quick Fixes**: One-click fixes for missing END blocks, semicolons, duplicate/unused declarations, unclosed strings
 - **Rename Symbol (F2)**: Rename variables, functions, FBs, programs with IEC 61131-3 validation
 - **Go to Definition & Find References**: Cross-file symbol navigation
 - **Function Block IntelliSense**: Auto-complete for FB members (`myTimer.Q`, `upCounter.CV`)
@@ -87,6 +87,11 @@ END_PROGRAM
 - **Unmatched blocks**: Missing `END_PROGRAM`, `END_IF`, `END_VAR`, etc.
 - **Unclosed strings**: Single-quoted (`STRING`) and double-quoted (`WSTRING`)
 - **Unmatched parentheses**: Per-line detection with string/comment awareness
+- **Missing semicolons**: Detects missing `;` on statement lines in POU bodies
+- **Duplicate declarations**: Same-name variables in the same scope (case-insensitive)
+- **Undefined variables**: Identifiers used but not declared, with fuzzy "did you mean?" matching
+- **Unused variables**: Local variables declared but never referenced in body
+- **Type mismatches**: Incompatible assignments (e.g., STRING to INT, BOOL to INT)
 - **Problems panel**: All diagnostics surface in `Ctrl+Shift+M` with source "ControlForge ST"
 - **Case-insensitive**: Keyword matching per IEC 61131-3
 
@@ -94,6 +99,9 @@ END_PROGRAM
 - **Missing END blocks**: Auto-insert `END_IF`, `END_FOR`, `END_WHILE`, `END_CASE`, `END_PROGRAM`, `END_FUNCTION`, `END_FUNCTION_BLOCK`, `END_VAR`, etc.
 - **Unclosed strings**: Append closing quote (single or double) at end of line
 - **Unmatched parentheses**: Insert missing closing `)` at end of expression
+- **Missing semicolons**: Insert `;` at end of statement
+- **Duplicate declarations**: Remove duplicate variable declaration line
+- **Unused variables**: Remove unused variable declaration line
 - **Light bulb menu**: Fixes appear via `Ctrl+.` or clicking the light bulb icon
 
 ### Code Formatting
@@ -129,12 +137,13 @@ END_PROGRAM
 - **Operating System**: Windows, macOS, or Linux
 
 ## What's New (Unreleased)
+- **Advanced Diagnostics**: Missing semicolons, duplicate declarations, undefined variables, unused variables, type mismatches — all with quick fixes
 - **Code Formatting**: Format Document (Shift+Alt+F) and Format Selection with keyword casing, operator spacing, indentation, VAR alignment
 - **Rename Symbol (F2)**: Rename variables, functions, FBs, programs with identifier validation and comment-awareness
 - **Code actions & quick fixes**: Auto-insert missing END blocks, close unclosed strings, fix unmatched parentheses via light bulb menu
 - **Real-time diagnostics**: Unmatched blocks, unclosed strings, unmatched parentheses shown in Problems panel as you type
 - **Multi-line declaration parsing**: Arrays, structs, and complex initializers now parse correctly
-- **307 unit tests**: Comprehensive coverage for all LSP providers, diagnostics, code actions, rename, and formatting
+- **353 unit tests**: Comprehensive coverage for all LSP providers, diagnostics, code actions, rename, and formatting
 
 ## What's New in v1.2.5
 - **Multi-line declaration parsing**: Arrays, structs, and complex initializers now parse correctly

--- a/manual-tests/README.md
+++ b/manual-tests/README.md
@@ -24,6 +24,11 @@ Files for testing syntax highlighting and language features:
 - `test_function_blocks.st` - Function block syntax highlighting
 - `test.st` - General syntax and language feature testing
 
+### `/diagnostics/` - Diagnostic & Linting Tests
+Files for testing real-time diagnostics and semantic analysis:
+- `semantic-checks.st` - Phase 2 semantic checks (missing semicolons, duplicates, undefined/unused vars, type mismatches)
+- `code-action-fixes.st` - Quick fixes for semantic diagnostics (insert semicolon, remove duplicate, remove unused)
+
 ## Purpose
 
 These files are used by:

--- a/manual-tests/diagnostics/code-action-fixes.st
+++ b/manual-tests/diagnostics/code-action-fixes.st
@@ -1,0 +1,31 @@
+(* Test: Code actions for semantic diagnostics *)
+(* Open this file, then use Ctrl+. on squiggles to verify quick fixes *)
+
+(* === Insert Semicolon === *)
+(* Expected: Quick fix to insert ';' *)
+PROGRAM SemicolonFixTest
+VAR
+    x : INT;
+END_VAR
+    x := 1  (* <-- hover, Ctrl+. should offer "Insert semicolon" *)
+END_PROGRAM
+
+(* === Remove Duplicate Declaration === *)
+(* Expected: Quick fix to remove the duplicate line *)
+PROGRAM DuplicateFixTest
+VAR
+    value : INT;
+    value : REAL;  (* <-- Ctrl+. should offer "Remove duplicate declaration" *)
+END_VAR
+    value := 0;
+END_PROGRAM
+
+(* === Remove Unused Variable === *)
+(* Expected: Quick fix to remove the unused variable line *)
+PROGRAM UnusedFixTest
+VAR
+    active : BOOL;
+    unused : INT;  (* <-- Ctrl+. should offer "Remove unused variable" *)
+END_VAR
+    active := TRUE;
+END_PROGRAM

--- a/manual-tests/diagnostics/semantic-checks.st
+++ b/manual-tests/diagnostics/semantic-checks.st
@@ -1,0 +1,72 @@
+(* Test: Semantic diagnostics - Phase 2 checks *)
+(* Open this file in VS Code to verify diagnostics appear correctly *)
+
+(* === Missing Semicolons === *)
+(* Expected: Error on line with missing semicolon *)
+PROGRAM MissingSemicolonTest
+VAR
+    x : INT := 0;
+    y : INT := 0;
+END_VAR
+    x := 1;
+    y := x + 2  (* <-- missing semicolon, should show error *)
+END_PROGRAM
+
+(* === Duplicate Declarations === *)
+(* Expected: Error on second declaration of 'counter' *)
+PROGRAM DuplicateVarTest
+VAR
+    counter : INT;
+    counter : REAL;  (* <-- duplicate, should show error *)
+    status : BOOL;
+END_VAR
+    counter := 1;
+    status := TRUE;
+END_PROGRAM
+
+(* === Undefined Variables === *)
+(* Expected: Warning on undeclared identifiers *)
+PROGRAM UndefinedVarTest
+VAR
+    x : INT;
+END_VAR
+    x := undeclaredVar;  (* <-- undefined, should show warning *)
+END_PROGRAM
+
+(* === Unused Variables === *)
+(* Expected: Warning on unused local variables *)
+PROGRAM UnusedVarTest
+VAR
+    used : INT;
+    unused : INT;  (* <-- never referenced in body, should show warning *)
+END_VAR
+    used := 42;
+END_PROGRAM
+
+(* === Type Mismatches === *)
+(* Expected: Error on incompatible assignment *)
+PROGRAM TypeMismatchTest
+VAR
+    count : INT;
+    flag : BOOL;
+END_VAR
+    count := 'hello';  (* <-- STRING to INT, should show error *)
+    flag := 42;         (* <-- INT to BOOL, should show error *)
+    count := 100;       (* <-- OK, INT to INT *)
+    flag := TRUE;       (* <-- OK, BOOL to BOOL *)
+END_PROGRAM
+
+(* === Valid Code - No Diagnostics Expected === *)
+PROGRAM CleanProgram
+VAR
+    i : INT;
+    sum : INT := 0;
+    running : BOOL := TRUE;
+END_VAR
+    FOR i := 1 TO 10 DO
+        sum := sum + i;
+    END_FOR;
+    IF sum > 50 THEN
+        running := FALSE;
+    END_IF;
+END_PROGRAM

--- a/src/server/providers/diagnostics-provider.ts
+++ b/src/server/providers/diagnostics-provider.ts
@@ -10,10 +10,19 @@
  *  - Unmatched VAR section keywords (VAR/END_VAR, VAR_INPUT/END_VAR, etc.)
  *  - Unclosed string literals (single and double quotes)
  *  - Unmatched parentheses within lines
+ *
+ * Phase 2 — semantic checks (require parsed symbols):
+ *  - Missing semicolons on statement lines
+ *  - Duplicate variable declarations in same scope
+ *  - Undefined variable usage
+ *  - Unused variable warnings
+ *  - Type mismatch on assignment
  */
 
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { Diagnostic, DiagnosticSeverity, Range, Position } from 'vscode-languageserver';
+import { STSymbolExtended, STSymbolKind, STScope } from '../../shared/types';
+import { IEC61131Specification, isKeyword, isDataType } from '../../iec61131_specification';
 
 // ─── Block keyword pairs ────────────────────────────────────────────────────
 
@@ -247,8 +256,7 @@ function checkUnmatchedBlocks(cleanLines: CleanLine[], rawLines: string[]): Diag
 }
 
 /**
- * Extract keyword-like tokens from an uppercased line.
- * Returns tokens that could be ST keywords (word characters including underscores).
+ * Extract keyword-like tokens from an uppercased line with their positions.
  */
 function extractKeywordTokens(lineUpper: string): { text: string; start: number }[] {
     const results: { text: string; start: number }[] = [];
@@ -259,10 +267,856 @@ function extractKeywordTokens(lineUpper: string): { text: string; start: number 
         results.push({ text: match[1], start: match.index });
     }
 
-    // Merge adjacent tokens that form compound keywords like FUNCTION_BLOCK, END_FUNCTION_BLOCK, etc.
-    // Actually our regex already handles underscores, so FUNCTION_BLOCK is one token. Good.
-
     return results;
+}
+
+// ─── Phase 2: Semantic checks ───────────────────────────────────────────────
+
+// ─── Build set of all known identifiers (keywords, types, functions, FBs) ───
+
+/** All known non-variable identifiers that should not trigger "undefined" warnings. */
+const ALL_KNOWN_IDENTIFIERS: Set<string> = (() => {
+    const s = new Set<string>();
+    for (const kw of IEC61131Specification.controlKeywords) s.add(kw);
+    for (const kw of IEC61131Specification.declarationKeywords) s.add(kw);
+    for (const kw of IEC61131Specification.otherKeywords) s.add(kw);
+    for (const kw of IEC61131Specification.logicalOperators) s.add(kw);
+    for (const kw of IEC61131Specification.dataTypes) s.add(kw);
+    for (const kw of IEC61131Specification.standardFunctionBlocks) s.add(kw);
+    for (const kw of IEC61131Specification.standardFunctions) s.add(kw);
+    // Additional tokens that appear in code but are not identifiers
+    s.add('REF');   // REF= syntax
+    s.add('ADR');   // Address-of operator
+    s.add('SIZEOF');
+    s.add('OF');
+    s.add('TO');
+    s.add('BY');
+    s.add('DO');
+    s.add('THEN');
+    s.add('ON');
+    s.add('WITH');
+    s.add('INTERVAL');
+    s.add('PRIORITY');
+    s.add('SINGLE');
+    return s;
+})();
+
+/**
+ * Keywords that introduce lines not requiring a trailing semicolon.
+ * Includes block openers/closers, control flow starts, and label-like patterns.
+ */
+const NO_SEMICOLON_KEYWORDS: Set<string> = new Set([
+    // Block openers/closers
+    'PROGRAM', 'END_PROGRAM', 'FUNCTION', 'END_FUNCTION',
+    'FUNCTION_BLOCK', 'END_FUNCTION_BLOCK',
+    'TYPE', 'END_TYPE', 'STRUCT', 'END_STRUCT',
+    'CLASS', 'END_CLASS', 'METHOD', 'END_METHOD',
+    'INTERFACE', 'END_INTERFACE', 'NAMESPACE', 'END_NAMESPACE',
+    'CONFIGURATION', 'END_CONFIGURATION', 'RESOURCE', 'END_RESOURCE',
+    // VAR sections
+    'VAR', 'VAR_INPUT', 'VAR_OUTPUT', 'VAR_IN_OUT', 'VAR_TEMP',
+    'VAR_GLOBAL', 'VAR_CONFIG', 'VAR_ACCESS', 'VAR_EXTERNAL', 'END_VAR',
+    // Control flow that uses THEN/DO/OF terminators
+    'IF', 'ELSIF', 'ELSE', 'END_IF',
+    'CASE', 'END_CASE',
+    'FOR', 'END_FOR',
+    'WHILE', 'END_WHILE',
+    'REPEAT', 'END_REPEAT',
+    'UNTIL',
+]);
+
+// ─── POU body range extraction ──────────────────────────────────────────────
+
+interface PouRange {
+    name: string;
+    /** Line of PROGRAM/FUNCTION/FUNCTION_BLOCK keyword */
+    startLine: number;
+    /** Line of END_PROGRAM/END_FUNCTION/END_FUNCTION_BLOCK keyword */
+    endLine: number;
+    /** Symbols (members) declared in this POU */
+    members: STSymbolExtended[];
+    /** Parameters for functions/FBs */
+    parameters: STSymbolExtended[];
+    /** POU kind */
+    kind: STSymbolKind;
+    /** Return type for functions */
+    returnType?: string;
+}
+
+/**
+ * Build POU ranges from symbols and raw lines.
+ * Each POU range covers the full extent from keyword to END_keyword.
+ */
+function buildPouRanges(symbols: STSymbolExtended[], rawLines: string[]): PouRange[] {
+    const ranges: PouRange[] = [];
+    const pouSymbols = symbols.filter(s =>
+        s.kind === STSymbolKind.Program ||
+        s.kind === STSymbolKind.Function ||
+        s.kind === STSymbolKind.FunctionBlock
+    );
+
+    for (const pou of pouSymbols) {
+        const startLine = pou.location.range.start.line;
+        const endKeyword = pou.kind === STSymbolKind.FunctionBlock
+            ? 'END_FUNCTION_BLOCK'
+            : pou.kind === STSymbolKind.Function
+                ? 'END_FUNCTION'
+                : 'END_PROGRAM';
+
+        let endLine = rawLines.length - 1;
+        let depth = 1;
+        const openKw = pou.kind === STSymbolKind.FunctionBlock
+            ? 'FUNCTION_BLOCK'
+            : pou.kind === STSymbolKind.Function
+                ? 'FUNCTION'
+                : 'PROGRAM';
+
+        for (let i = startLine + 1; i < rawLines.length; i++) {
+            const trimmed = stripInlineComments(rawLines[i]).trim().toUpperCase();
+            if (!trimmed) continue;
+            const kwRegex = new RegExp(`^${openKw}\\b`);
+            if (kwRegex.test(trimmed)) depth++;
+            else if (trimmed.startsWith(endKeyword)) {
+                depth--;
+                if (depth === 0) { endLine = i; break; }
+            }
+        }
+
+        // Collect members and params from the flat symbol list
+        const members = symbols.filter(s =>
+            s.parentSymbol === pou.name &&
+            (s.kind === STSymbolKind.Variable || s.kind === STSymbolKind.FunctionBlockInstance)
+        );
+
+        const parameters = pou.parameters
+            ? symbols.filter(s =>
+                s.parentSymbol === pou.name &&
+                (s.scope === STScope.Input || s.scope === STScope.Output || s.scope === STScope.InOut))
+            : [];
+
+        ranges.push({
+            name: pou.name,
+            startLine,
+            endLine,
+            members,
+            parameters,
+            kind: pou.kind,
+            returnType: pou.returnType,
+        });
+    }
+
+    return ranges;
+}
+
+// ─── VAR section range detection ────────────────────────────────────────────
+
+interface VarSectionRange {
+    startLine: number;
+    endLine: number;
+}
+
+/**
+ * Find all VAR section ranges (VAR...END_VAR) within a line range.
+ */
+function findVarSections(cleanLines: CleanLine[], fromLine: number, toLine: number): VarSectionRange[] {
+    const sections: VarSectionRange[] = [];
+    const varRegex = /^\s*VAR(_INPUT|_OUTPUT|_IN_OUT|_GLOBAL|_TEMP|_CONFIG|_ACCESS|_EXTERNAL)?\s*(CONSTANT|RETAIN|PERSISTENT|NON_RETAIN)?\s*$/i;
+
+    for (const cl of cleanLines) {
+        if (cl.lineIndex < fromLine || cl.lineIndex > toLine) continue;
+        if (!varRegex.test(cl.text)) continue;
+
+        const start = cl.lineIndex;
+        let end = toLine;
+        for (const cl2 of cleanLines) {
+            if (cl2.lineIndex <= start) continue;
+            if (cl2.lineIndex > toLine) break;
+            if (cl2.text.trim().toUpperCase().startsWith('END_VAR')) {
+                end = cl2.lineIndex;
+                break;
+            }
+        }
+        sections.push({ startLine: start, endLine: end });
+    }
+
+    return sections;
+}
+
+/**
+ * Check if a line is inside any VAR section.
+ */
+function isInVarSection(lineIndex: number, varSections: VarSectionRange[]): boolean {
+    return varSections.some(s => lineIndex >= s.startLine && lineIndex <= s.endLine);
+}
+
+// ─── Strip inline comments (single-line only, for quick checks) ─────────
+
+function stripInlineComments(line: string): string {
+    let result = '';
+    let inString = false;
+    let stringChar = '';
+    let i = 0;
+
+    while (i < line.length) {
+        const ch = line[i];
+
+        if (inString) {
+            result += ch;
+            if (ch === stringChar) {
+                if (i + 1 < line.length && line[i + 1] === stringChar) {
+                    result += line[i + 1];
+                    i += 2;
+                    continue;
+                }
+                inString = false;
+            }
+            i++;
+            continue;
+        }
+
+        if (ch === "'" || ch === '"') {
+            inString = true;
+            stringChar = ch;
+            result += ch;
+            i++;
+            continue;
+        }
+
+        if (ch === '/' && i + 1 < line.length && line[i + 1] === '/') {
+            break; // rest is comment
+        }
+
+        if (ch === '(' && i + 1 < line.length && line[i + 1] === '*') {
+            const endIdx = line.indexOf('*)', i + 2);
+            if (endIdx !== -1) {
+                i = endIdx + 2;
+                continue;
+            }
+            break; // block comment to end of line
+        }
+
+        result += ch;
+        i++;
+    }
+
+    return result;
+}
+
+// ─── Missing semicolons ────────────────────────────────────────────────────
+
+/**
+ * Detect lines inside POU bodies (outside VAR sections) that appear to be
+ * statements but are missing a trailing semicolon.
+ *
+ * Skips: blank lines, comment-only lines, block opener/closer keywords,
+ * control flow keywords (IF/THEN, FOR/DO, etc.), CASE branch labels,
+ * multi-line continuations (unbalanced parens).
+ */
+function checkMissingSemicolons(cleanLines: CleanLine[], rawLines: string[]): Diagnostic[] {
+    const diagnostics: Diagnostic[] = [];
+
+    // Find POU boundaries
+    const pouBoundaries = findPouBoundaries(cleanLines);
+
+    for (const pou of pouBoundaries) {
+        const varSections = findVarSections(cleanLines, pou.startLine, pou.endLine);
+        let parenDepth = 0;
+
+        for (const cl of cleanLines) {
+            if (cl.lineIndex <= pou.startLine || cl.lineIndex >= pou.endLine) continue;
+            if (isInVarSection(cl.lineIndex, varSections)) continue;
+
+            const trimmed = cl.text.trim();
+            if (!trimmed) continue;
+
+            // Track multi-line paren continuations (FB calls etc.)
+            for (const ch of trimmed) {
+                if (ch === '(') parenDepth++;
+                else if (ch === ')') parenDepth--;
+            }
+            if (parenDepth < 0) parenDepth = 0;
+
+            // If we're inside an open paren group, skip semicolon check
+            if (parenDepth > 0) continue;
+
+            // Get the leading keyword token
+            const firstToken = getFirstKeywordToken(trimmed);
+
+            // Skip lines starting with block/control keywords
+            if (firstToken && NO_SEMICOLON_KEYWORDS.has(firstToken)) continue;
+
+            // Skip CASE branch labels: patterns like "1:", "1..10:", "STOPPED:", "'a':"
+            if (isCaseBranchLabel(trimmed)) continue;
+
+            // Skip lines that end with THEN, DO, OF (control flow terminators)
+            const upperTrimmed = trimmed.toUpperCase();
+            if (upperTrimmed.endsWith('THEN') || upperTrimmed.endsWith('DO') ||
+                upperTrimmed.endsWith('OF')) continue;
+
+            // At this point, line should be a statement. Check for semicolon.
+            if (!trimmed.endsWith(';')) {
+                const rawLine = rawLines[cl.lineIndex];
+                const lastNonSpace = rawLine.trimEnd().length;
+                diagnostics.push(createDiagnostic(
+                    cl.lineIndex, lastNonSpace > 0 ? lastNonSpace - 1 : 0, 1,
+                    'Missing semicolon at end of statement',
+                    DiagnosticSeverity.Error
+                ));
+            }
+        }
+    }
+
+    return diagnostics;
+}
+
+/**
+ * Get the first keyword-like token from a line (uppercase).
+ */
+function getFirstKeywordToken(trimmedLine: string): string | null {
+    const match = trimmedLine.match(/^([A-Za-z_][A-Za-z0-9_]*)/);
+    return match ? match[1].toUpperCase() : null;
+}
+
+/**
+ * Check if a line looks like a CASE branch label.
+ * Patterns: `0:`, `1..10:`, `STOPPED:`, `'a':`, `ELSE`, standalone numbers with colon.
+ */
+function isCaseBranchLabel(trimmedLine: string): boolean {
+    const upper = trimmedLine.toUpperCase();
+    if (upper === 'ELSE') return false; // ELSE is handled by NO_SEMICOLON_KEYWORDS
+
+    // Numeric or range label: "0:", "1..10:", "16#FF:"
+    if (/^[0-9]/.test(trimmedLine) && trimmedLine.endsWith(':')) return true;
+
+    // Enum/identifier label: "STOPPED:", "RUNNING:"
+    if (/^[A-Za-z_]\w*\s*:$/.test(trimmedLine)) return true;
+
+    // String label: "'A':"
+    if (/^'[^']*'\s*:$/.test(trimmedLine)) return true;
+
+    // Range with identifiers: "1..10:" with possible spaces
+    if (/^[\w#]+\s*\.\.\s*[\w#]+\s*:$/.test(trimmedLine)) return true;
+
+    // Multiple comma-separated labels: "1, 2, 3:"
+    if (/^[\w#']+(\s*,\s*[\w#']+)*\s*:$/.test(trimmedLine)) return true;
+
+    return false;
+}
+
+interface PouBoundary {
+    startLine: number;
+    endLine: number;
+}
+
+/**
+ * Find POU boundaries from clean lines (PROGRAM...END_PROGRAM, etc.)
+ */
+function findPouBoundaries(cleanLines: CleanLine[]): PouBoundary[] {
+    const boundaries: PouBoundary[] = [];
+    const pouStartRegex = /^\s*(PROGRAM|FUNCTION_BLOCK|FUNCTION)\b/i;
+
+    for (const cl of cleanLines) {
+        const match = cl.text.match(pouStartRegex);
+        if (!match) continue;
+
+        const keyword = match[1].toUpperCase();
+        const endKeyword = `END_${keyword}`;
+        let depth = 1;
+        let endLine = -1;
+
+        for (const cl2 of cleanLines) {
+            if (cl2.lineIndex <= cl.lineIndex) continue;
+            const trimmed = cl2.text.trim().toUpperCase();
+            if (!trimmed) continue;
+
+            // Check for nested same POU type
+            const nestRegex = new RegExp(`^${keyword}\\b`);
+            if (nestRegex.test(trimmed)) depth++;
+            else if (trimmed.startsWith(endKeyword)) {
+                depth--;
+                if (depth === 0) { endLine = cl2.lineIndex; break; }
+            }
+        }
+
+        if (endLine > 0) {
+            boundaries.push({ startLine: cl.lineIndex, endLine });
+        }
+    }
+
+    return boundaries;
+}
+
+// ─── Duplicate declarations ─────────────────────────────────────────────────
+
+/**
+ * Detect duplicate variable declarations within the same scope (POU).
+ * IEC 61131-3 identifiers are case-insensitive, so "myVar" and "MYVAR"
+ * in the same POU are duplicates.
+ */
+function checkDuplicateDeclarations(symbols: STSymbolExtended[]): Diagnostic[] {
+    const diagnostics: Diagnostic[] = [];
+
+    // Group vars by parent POU (null parent = global scope)
+    const byParent = new Map<string, STSymbolExtended[]>();
+
+    for (const sym of symbols) {
+        if (sym.kind !== STSymbolKind.Variable &&
+            sym.kind !== STSymbolKind.FunctionBlockInstance) continue;
+
+        const parent = sym.parentSymbol || '__global__';
+        if (!byParent.has(parent)) byParent.set(parent, []);
+        byParent.get(parent)!.push(sym);
+    }
+
+    for (const [_parent, vars] of byParent) {
+        const seen = new Map<string, STSymbolExtended>();
+
+        for (const v of vars) {
+            const normalized = v.name.toLowerCase();
+            const existing = seen.get(normalized);
+
+            if (existing) {
+                diagnostics.push(createDiagnostic(
+                    v.location.range.start.line,
+                    v.location.range.start.character,
+                    v.name.length,
+                    `Duplicate declaration '${v.name}' (already declared as '${existing.name}')`,
+                    DiagnosticSeverity.Error
+                ));
+            } else {
+                seen.set(normalized, v);
+            }
+        }
+    }
+
+    return diagnostics;
+}
+
+// ─── Undefined variable detection ───────────────────────────────────────────
+
+/**
+ * Scan POU body lines for identifier tokens not declared in the POU's scope.
+ *
+ * Excluded from "undefined" checks:
+ *  - All IEC keywords, data types, standard FBs, standard functions
+ *  - The POU's own name (PROGRAM Foo — "Foo" is known)
+ *  - CASE branch labels (enum values may be user-defined types)
+ *  - Member access targets after dot (instance.Member — "Member" checked elsewhere)
+ *  - Numeric literals, hex literals
+ *  - Function/FB names used as calls
+ *  - Other POUs visible in the same file (cross-POU references)
+ *  - Global variables
+ */
+function checkUndefinedVariables(
+    cleanLines: CleanLine[],
+    rawLines: string[],
+    symbols: STSymbolExtended[]
+): Diagnostic[] {
+    const diagnostics: Diagnostic[] = [];
+    const pouRanges = buildPouRanges(symbols, rawLines);
+
+    // Build cross-file POU name set (all programs, functions, FBs in file)
+    const pouNames = new Set<string>();
+    const globalVarNames = new Set<string>();
+    for (const sym of symbols) {
+        if (sym.kind === STSymbolKind.Program ||
+            sym.kind === STSymbolKind.Function ||
+            sym.kind === STSymbolKind.FunctionBlock) {
+            pouNames.add(sym.name.toUpperCase());
+        }
+        if (!sym.parentSymbol && (sym.kind === STSymbolKind.Variable || sym.kind === STSymbolKind.FunctionBlockInstance)) {
+            globalVarNames.add(sym.name.toUpperCase());
+        }
+    }
+
+    // Build set of all user-defined TYPE names (TYPE...END_TYPE)
+    const userTypeNames = new Set<string>();
+    for (const cl of cleanLines) {
+        const typeMatch = cl.text.match(/^\s*TYPE\s+(\w+)/i);
+        if (typeMatch) {
+            userTypeNames.add(typeMatch[1].toUpperCase());
+        }
+    }
+
+    for (const pou of pouRanges) {
+        // Build declared identifiers set for this POU
+        const declaredNames = new Set<string>();
+        declaredNames.add(pou.name.toUpperCase()); // POU's own name
+
+        for (const member of pou.members) {
+            declaredNames.add(member.name.toUpperCase());
+        }
+        for (const param of pou.parameters) {
+            declaredNames.add(param.name.toUpperCase());
+        }
+
+        const varSections = findVarSections(cleanLines, pou.startLine, pou.endLine);
+
+        // Track CASE statement context to allow enum values
+        let inCaseOf = false;
+
+        for (const cl of cleanLines) {
+            if (cl.lineIndex <= pou.startLine || cl.lineIndex >= pou.endLine) continue;
+            if (isInVarSection(cl.lineIndex, varSections)) continue;
+
+            const trimmed = cl.text.trim();
+            if (!trimmed) continue;
+
+            const upperTrimmed = trimmed.toUpperCase();
+
+            // Track CASE context
+            if (/^CASE\b/i.test(trimmed)) inCaseOf = true;
+            if (upperTrimmed.startsWith('END_CASE')) inCaseOf = false;
+
+            // Skip CASE branch labels entirely — they reference enum values
+            // which may be from user-defined types
+            if (inCaseOf && isCaseBranchLabel(trimmed)) continue;
+
+            // Extract identifier tokens, skipping members after dots
+            const tokens = extractBodyIdentifiers(trimmed);
+
+            for (const token of tokens) {
+                const upper = token.name.toUpperCase();
+
+                // Skip known identifiers
+                if (ALL_KNOWN_IDENTIFIERS.has(upper)) continue;
+                if (declaredNames.has(upper)) continue;
+                if (pouNames.has(upper)) continue;
+                if (globalVarNames.has(upper)) continue;
+                if (userTypeNames.has(upper)) continue;
+
+                // Skip numeric-looking tokens (hex literals like 16#FF produce "FF" after stripping)
+                if (/^\d/.test(token.name)) continue;
+
+                // Skip enum member values that look like identifiers in CASE branches
+                if (inCaseOf) continue;
+
+                diagnostics.push(createDiagnostic(
+                    cl.lineIndex,
+                    token.column,
+                    token.name.length,
+                    `Undefined identifier '${token.name}'`,
+                    DiagnosticSeverity.Warning
+                ));
+            }
+        }
+    }
+
+    return diagnostics;
+}
+
+interface BodyToken {
+    name: string;
+    column: number;
+}
+
+/**
+ * Extract identifier tokens from a body line, skipping:
+ *  - members after dots (instance.member — skip "member")
+ *  - string contents
+ *  - numeric literals and hex prefix parts
+ *  - named parameter assigns in FB calls (paramName :=)
+ */
+function extractBodyIdentifiers(line: string): BodyToken[] {
+    const tokens: BodyToken[] = [];
+    const noStrings = stripStringLiterals(line);
+
+    // Find all identifier-like tokens
+    const regex = /\b([A-Za-z_][A-Za-z0-9_]*)\b/g;
+    let match: RegExpExecArray | null;
+
+    while ((match = regex.exec(noStrings)) !== null) {
+        const name = match[1];
+        const col = match.index;
+
+        // Skip if preceded by dot (member access)
+        if (col > 0 && noStrings[col - 1] === '.') continue;
+
+        // Skip if preceded by # (typed literal: TIME#, T#, etc.)
+        if (col > 0 && noStrings[col - 1] === '#') continue;
+
+        tokens.push({ name, column: col });
+    }
+
+    return tokens;
+}
+
+// ─── Unused variable warnings ───────────────────────────────────────────────
+
+/**
+ * Detect variables declared in a POU but never referenced in its body.
+ * Only checks local variables (not Input/Output/InOut which have external callers).
+ */
+function checkUnusedVariables(
+    cleanLines: CleanLine[],
+    rawLines: string[],
+    symbols: STSymbolExtended[]
+): Diagnostic[] {
+    const diagnostics: Diagnostic[] = [];
+    const pouRanges = buildPouRanges(symbols, rawLines);
+
+    for (const pou of pouRanges) {
+        // Only check local-scoped variables (not params visible to callers)
+        const localVars = pou.members.filter(m => m.scope === STScope.Local);
+
+        if (localVars.length === 0) continue;
+
+        const varSections = findVarSections(cleanLines, pou.startLine, pou.endLine);
+
+        // Collect all body text (outside VAR sections) into a single string for scanning
+        let bodyText = '';
+        for (const cl of cleanLines) {
+            if (cl.lineIndex <= pou.startLine || cl.lineIndex >= pou.endLine) continue;
+            if (isInVarSection(cl.lineIndex, varSections)) continue;
+            bodyText += ' ' + cl.text;
+        }
+        const bodyUpper = bodyText.toUpperCase();
+
+        for (const v of localVars) {
+            const nameUpper = v.name.toUpperCase();
+            // Check for whole-word occurrence in body
+            const regex = new RegExp(`\\b${escapeRegex(nameUpper)}\\b`);
+            if (!regex.test(bodyUpper)) {
+                diagnostics.push(createDiagnostic(
+                    v.location.range.start.line,
+                    v.location.range.start.character,
+                    v.name.length,
+                    `Variable '${v.name}' is declared but never used`,
+                    DiagnosticSeverity.Warning
+                ));
+            }
+        }
+    }
+
+    return diagnostics;
+}
+
+function escapeRegex(s: string): string {
+    return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+// ─── Type mismatch detection ────────────────────────────────────────────────
+
+/**
+ * Type compatibility matrix for basic IEC 61131-3 types.
+ * Groups types into compatible families for assignment checking.
+ */
+const TYPE_FAMILIES: Map<string, string> = new Map([
+    // Boolean family
+    ['BOOL', 'BOOL'],
+    // Integer family
+    ['SINT', 'INT'], ['USINT', 'INT'], ['INT', 'INT'], ['UINT', 'INT'],
+    ['DINT', 'INT'], ['UDINT', 'INT'], ['LINT', 'INT'], ['ULINT', 'INT'],
+    ['BYTE', 'INT'], ['WORD', 'INT'], ['DWORD', 'INT'], ['LWORD', 'INT'],
+    // Real family
+    ['REAL', 'REAL'], ['LREAL', 'REAL'],
+    // String family
+    ['STRING', 'STRING'], ['WSTRING', 'WSTRING'],
+    ['CHAR', 'STRING'], ['WCHAR', 'WSTRING'],
+    // Time family
+    ['TIME', 'TIME'], ['LTIME', 'TIME'],
+    // Date family
+    ['DATE', 'DATE'], ['LDATE', 'DATE'],
+    ['TIME_OF_DAY', 'TOD'], ['TOD', 'TOD'],
+    ['DATE_AND_TIME', 'DT'], ['DT', 'DT'],
+]);
+
+/**
+ * Check if two types are assignment-compatible.
+ * INT family types are compatible with each other.
+ * REAL family types are compatible with each other and with INT family.
+ * Everything else must match families exactly.
+ */
+function areTypesCompatible(lhsType: string, rhsType: string): boolean {
+    const lhs = lhsType.toUpperCase();
+    const rhs = rhsType.toUpperCase();
+
+    if (lhs === rhs) return true;
+
+    const lhsFamily = TYPE_FAMILIES.get(lhs);
+    const rhsFamily = TYPE_FAMILIES.get(rhs);
+
+    // Unknown types (user-defined) — assume compatible
+    if (!lhsFamily || !rhsFamily) return true;
+
+    if (lhsFamily === rhsFamily) return true;
+
+    // REAL can accept INT (implicit widening)
+    if (lhsFamily === 'REAL' && rhsFamily === 'INT') return true;
+
+    return false;
+}
+
+/**
+ * Detect type mismatches on assignment statements (`:=`).
+ * Only checks assignments where both LHS and RHS types can be determined:
+ *  - LHS: variable with known dataType from symbol table
+ *  - RHS: literal value or known-type variable
+ */
+function checkTypeMismatches(
+    cleanLines: CleanLine[],
+    symbols: STSymbolExtended[]
+): Diagnostic[] {
+    const diagnostics: Diagnostic[] = [];
+
+    // Build symbol lookup by normalized name
+    const symByName = new Map<string, STSymbolExtended>();
+    for (const sym of symbols) {
+        if (sym.kind === STSymbolKind.Variable ||
+            sym.kind === STSymbolKind.FunctionBlockInstance) {
+            const key = (sym.parentSymbol || '') + '::' + sym.name.toUpperCase();
+            if (!symByName.has(key)) symByName.set(key, sym);
+            // Also store without parent for global lookup
+            const globalKey = sym.name.toUpperCase();
+            if (!symByName.has(globalKey)) symByName.set(globalKey, sym);
+        }
+    }
+
+    // Simple assignment pattern: identifier := value;
+    const assignRegex = /^\s*([A-Za-z_]\w*)\s*:=\s*(.+?)\s*;\s*$/;
+
+    for (const cl of cleanLines) {
+        const match = cl.text.match(assignRegex);
+        if (!match) continue;
+
+        const lhsName = match[1];
+        const rhsExpr = match[2].trim();
+
+        // Find LHS type
+        const lhsKey = lhsName.toUpperCase();
+        const lhsSym = symByName.get(lhsKey);
+        if (!lhsSym || !lhsSym.dataType) continue;
+
+        const lhsType = lhsSym.dataType.toUpperCase();
+
+        // Determine RHS type from literals or known variables
+        const rhsType = inferExpressionType(rhsExpr, symByName);
+        if (!rhsType) continue;
+
+        if (!areTypesCompatible(lhsType, rhsType)) {
+            diagnostics.push(createDiagnostic(
+                cl.lineIndex,
+                cl.text.indexOf(':='),
+                match[0].trim().length,
+                `Type mismatch: cannot assign '${rhsType}' to '${lhsType}'`,
+                DiagnosticSeverity.Error
+            ));
+        }
+    }
+
+    return diagnostics;
+}
+
+/**
+ * Infer the type of a simple RHS expression.
+ * Handles: literals, single variables, typed literals.
+ * Returns null if type cannot be determined (complex expressions).
+ */
+function inferExpressionType(expr: string, symByName: Map<string, STSymbolExtended>): string | null {
+    const trimmed = expr.trim();
+    const upper = trimmed.toUpperCase();
+
+    // Boolean literals
+    if (upper === 'TRUE' || upper === 'FALSE') return 'BOOL';
+
+    // String literals
+    if (trimmed.startsWith("'") && trimmed.endsWith("'")) {
+        return trimmed.length === 3 ? 'CHAR' : 'STRING';
+    }
+    if (trimmed.startsWith('"') && trimmed.endsWith('"')) return 'WSTRING';
+
+    // Typed literals: TIME#, T#, DATE#, etc.
+    if (upper.startsWith('LTIME#') || upper.startsWith('LT#')) return 'LTIME';
+    if (upper.startsWith('TIME#') || upper.startsWith('T#')) return 'TIME';
+    if (upper.startsWith('LDATE#') || upper.startsWith('LD#')) return 'LDATE';
+    if (upper.startsWith('DATE#') || upper.startsWith('D#')) return 'DATE';
+    if (upper.startsWith('DT#') || upper.startsWith('DATE_AND_TIME#')) return 'DATE_AND_TIME';
+    if (upper.startsWith('TOD#') || upper.startsWith('TIME_OF_DAY#')) return 'TIME_OF_DAY';
+
+    // Real literal (contains decimal point, no prefix)
+    if (/^[+-]?[0-9]+\.[0-9]+$/.test(trimmed)) return 'REAL';
+
+    // Integer literal (plain digits, no prefix)
+    if (/^[+-]?[0-9]+$/.test(trimmed)) return 'INT';
+
+    // Hex literal: 16#FF
+    if (/^16#[0-9A-Fa-f]+$/.test(trimmed)) return 'INT';
+
+    // Single identifier — look up type
+    if (/^[A-Za-z_]\w*$/.test(trimmed)) {
+        const sym = symByName.get(upper);
+        if (sym && sym.dataType) return sym.dataType.toUpperCase();
+    }
+
+    // NOT <expr> — result is BOOL
+    if (upper.startsWith('NOT ')) return 'BOOL';
+
+    // Complex expressions — cannot determine type
+    return null;
+}
+
+// ─── Fuzzy matching for "did you mean?" suggestions ─────────────────────────
+
+/**
+ * Compute Levenshtein distance between two strings.
+ */
+export function levenshteinDistance(a: string, b: string): number {
+    const m = a.length;
+    const n = b.length;
+
+    if (m === 0) return n;
+    if (n === 0) return m;
+
+    const dp: number[][] = Array.from({ length: m + 1 }, () => Array(n + 1).fill(0) as number[]);
+
+    for (let i = 0; i <= m; i++) dp[i][0] = i;
+    for (let j = 0; j <= n; j++) dp[0][j] = j;
+
+    for (let i = 1; i <= m; i++) {
+        for (let j = 1; j <= n; j++) {
+            const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+            dp[i][j] = Math.min(
+                dp[i - 1][j] + 1,       // deletion
+                dp[i][j - 1] + 1,       // insertion
+                dp[i - 1][j - 1] + cost // substitution
+            );
+        }
+    }
+
+    return dp[m][n];
+}
+
+/**
+ * Find the closest matching identifier for a given name.
+ * Used by code actions to provide "Did you mean?" suggestions.
+ *
+ * @param name The unrecognized identifier
+ * @param candidates Available identifiers to match against
+ * @param maxDistance Maximum edit distance to consider (default: 3)
+ * @returns Best match or null if none within distance threshold
+ */
+export function findClosestMatch(
+    name: string,
+    candidates: string[],
+    maxDistance: number = 3
+): string | null {
+    const upper = name.toUpperCase();
+    let best: string | null = null;
+    let bestDist = maxDistance + 1;
+
+    for (const candidate of candidates) {
+        // Quick length filter — edit distance >= length difference
+        const lenDiff = Math.abs(upper.length - candidate.length);
+        if (lenDiff > maxDistance) continue;
+
+        const dist = levenshteinDistance(upper, candidate.toUpperCase());
+        if (dist < bestDist) {
+            bestDist = dist;
+            best = candidate;
+        }
+    }
+
+    return bestDist <= maxDistance ? best : null;
 }
 
 /**
@@ -500,19 +1354,33 @@ function createDiagnostic(
 /**
  * Compute diagnostics for a Structured Text document.
  *
- * Returns an array of LSP Diagnostic objects ready to be sent via
- * `connection.sendDiagnostics()`.
+ * When `symbols` is provided (from STASTParser), semantic checks run
+ * in addition to syntax checks: missing semicolons, duplicate declarations,
+ * undefined variables, unused variables, type mismatches.
+ *
+ * @param document The text document
+ * @param symbols Optional parsed symbols from STASTParser for semantic analysis
  */
-export function computeDiagnostics(document: TextDocument): Diagnostic[] {
+export function computeDiagnostics(document: TextDocument, symbols?: STSymbolExtended[]): Diagnostic[] {
     const text = document.getText();
     const rawLines = text.split('\n');
     const cleanLines = stripAllComments(rawLines);
 
     const diagnostics: Diagnostic[] = [];
 
+    // Phase 1: syntax checks
     diagnostics.push(...checkUnmatchedBlocks(cleanLines, rawLines));
     diagnostics.push(...checkUnclosedStrings(cleanLines));
     diagnostics.push(...checkUnmatchedParentheses(cleanLines));
+
+    // Phase 2: semantic checks (only when symbols available)
+    if (symbols && symbols.length > 0) {
+        diagnostics.push(...checkMissingSemicolons(cleanLines, rawLines));
+        diagnostics.push(...checkDuplicateDeclarations(symbols));
+        diagnostics.push(...checkUndefinedVariables(cleanLines, rawLines, symbols));
+        diagnostics.push(...checkUnusedVariables(cleanLines, rawLines, symbols));
+        diagnostics.push(...checkTypeMismatches(cleanLines, symbols));
+    }
 
     return diagnostics;
 }

--- a/src/test/unit/code-action-provider.unit.test.ts
+++ b/src/test/unit/code-action-provider.unit.test.ts
@@ -616,4 +616,69 @@ VAR
             }
         });
     });
+
+    suite('Missing Semicolons', () => {
+        test('should provide fix for missing semicolon', () => {
+            const content = `PROGRAM Main
+VAR
+    x : INT;
+END_VAR
+    x := 1
+END_PROGRAM`;
+            const document = doc(content);
+            const diagnostic = createDiagnostic(4, 9, 1, 'Missing semicolon at end of statement');
+            const params = createParams(document, [diagnostic]);
+
+            const actions = provideCodeActions(document, params);
+
+            assert.strictEqual(actions.length, 1);
+            assert.strictEqual(actions[0].title, 'Insert semicolon');
+            assert.strictEqual(actions[0].kind, CodeActionKind.QuickFix);
+
+            const edit = actions[0].edit!.changes![document.uri][0];
+            assert.strictEqual(edit.newText, ';');
+        });
+    });
+
+    suite('Duplicate Declarations', () => {
+        test('should provide fix to remove duplicate declaration', () => {
+            const content = `PROGRAM Main
+VAR
+    x : INT;
+    x : REAL;
+END_VAR
+END_PROGRAM`;
+            const document = doc(content);
+            const diagnostic = createDiagnostic(3, 4, 1, "Duplicate declaration 'x' (already declared as 'x')");
+            const params = createParams(document, [diagnostic]);
+
+            const actions = provideCodeActions(document, params);
+
+            assert.strictEqual(actions.length, 1);
+            assert.strictEqual(actions[0].title, 'Remove duplicate declaration');
+            assert.strictEqual(actions[0].kind, CodeActionKind.QuickFix);
+        });
+    });
+
+    suite('Unused Variables', () => {
+        test('should provide fix to remove unused variable', () => {
+            const content = `PROGRAM Main
+VAR
+    x : INT;
+    unused : INT;
+END_VAR
+    x := 1;
+END_PROGRAM`;
+            const document = doc(content);
+            const diagnostic = createDiagnostic(3, 4, 6, "Variable 'unused' is declared but never used");
+            const params = createParams(document, [diagnostic]);
+
+            const actions = provideCodeActions(document, params);
+
+            assert.strictEqual(actions.length, 1);
+            assert.strictEqual(actions[0].title, 'Remove unused variable');
+            assert.strictEqual(actions[0].kind, CodeActionKind.QuickFix);
+            assert.strictEqual(actions[0].isPreferred, true);
+        });
+    });
 });


### PR DESCRIPTION
## Summary

- Add Phase 2 semantic diagnostics: missing semicolons, duplicate declarations, undefined variables, unused variables, type mismatches with "did you mean?" suggestions
- Add Phase 2 quick fixes: insert semicolon, remove duplicate declaration, remove unused variable
- Closes #6

## Testing

- `npm run test:unit`: 353 passing (46 new tests for Phase 2 checks, code actions, levenshtein, false-positive coverage)
- `npm run webpack-prod`: clean (pre-existing vscode-languageserver-types warning only)
- Manual test fixtures added: `manual-tests/diagnostics/semantic-checks.st`, `manual-tests/diagnostics/code-action-fixes.st`