### PR TITLE
Change license to MIT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Changed
+- License changed from BUSL-1.1 to MIT (#78)
+
 ### Fixed
 - Parser regex fails on multi-line variable declarations (#41)
 - Verbose console.log in definition provider polluting test and server output

--- a/LICENSE
+++ b/LICENSE
@@ -1,37 +1,21 @@
-Business Source License 1.1
+MIT License
 
-Parameters:
+Copyright (c) 2025 Michael Distel
 
-  Licensed Work:         ControlForge Structured Text
-  Licensor:              Michael Distel
-  Copyright Notice:      Copyright (c) 2025 Michael Distel
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-  Additional Use Grant:  None
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-  Change Date:           2029-06-09
-  Change License:        GPL-3.0-or-later
-
-Terms:
-
-The Licensor grants you the right to copy, modify, create derivative works,
-and use the Licensed Work for any purpose, except for any use that is
-prohibited by the Additional Use Grant, if any.
-
-This license terminates on the Change Date and the Licensed Work becomes
-available under the Change License.
-
-You must conspicuously display this license on each original or modified
-copy of the Licensed Work. If you receive the Licensed Work in object code
-form, you may produce a readable copy of this license from the object code
-form if required by this license.
-
-THIS SOFTWARE IS PROVIDED BY THE LICENSOR "AS IS" AND ANY EXPRESS OR
-IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
-OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
-IN NO EVENT SHALL THE LICENSOR BE LIABLE FOR ANY DIRECT, INDIRECT,
-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
-THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "1.2.5",
   "author": "Michael Distel",
   "publisher": "ControlForgeSystems",
-  "license": "BUSL-1.1",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ControlForge-Systems/controlforge-structured-text"


### PR DESCRIPTION
## Summary
- Nobody has ever looked at a VS Code extension and thought 'yes, Business Source License, perfect'
- It was silly not to make it MIT from the start — fixing that now
- Update `package.json` license field to `MIT`
- Closes #78

## Testing
- `npm run test:unit`: 366 passing