### PR TITLE
Discourage category prefixes in issue titles

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -7,7 +7,7 @@ body:
     attributes:
       label: Problem
       description: What's broken? Be concise.
-      placeholder: Go to definition fails when symbol casing differs from declaration.
+      placeholder: "Go to definition fails when symbol casing differs from declaration.\n\nNote: do not prefix the issue title with category labels — use labels instead."
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -7,7 +7,7 @@ body:
     attributes:
       label: Summary
       description: What and why, in 1-3 sentences.
-      placeholder: Add signature help for function calls. Popup shows parameter names, types, and current position when typing function arguments.
+      placeholder: "Add signature help for function calls. Popup shows parameter names, types, and current position when typing function arguments.\n\nNote: do not prefix the issue title with category labels (e.g. 'Grammar:', 'Diagnostic:') — use labels instead."
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/idea.yml
+++ b/.github/ISSUE_TEMPLATE/idea.yml
@@ -7,7 +7,7 @@ body:
     attributes:
       label: Summary
       description: What is the idea? 1-3 sentences.
-      placeholder: Simulate execution of ST code in a virtual runtime for testing logic without a physical PLC.
+      placeholder: "Simulate execution of ST code in a virtual runtime for testing logic without a physical PLC.\n\nNote: do not prefix the issue title with category labels — use labels instead."
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/technical-debt.yml
+++ b/.github/ISSUE_TEMPLATE/technical-debt.yml
@@ -7,7 +7,7 @@ body:
     attributes:
       label: Context
       description: Why does this need doing? What triggered it?
-      placeholder: Dead code audit after parser rewrite (#41) found significant unused code.
+      placeholder: "Dead code audit after parser rewrite (#41) found significant unused code.\n\nNote: do not prefix the issue title with category labels — use labels instead."
     validations:
       required: true
 


### PR DESCRIPTION
## Summary

- Add note to all issue templates instructing authors not to prefix titles with category labels (e.g. Grammar:, Diagnostic:, Vendor:) — labels already communicate this
- Stripped existing prefixes from all affected issues (#55–#95)

## Testing

- No code changes; template-only
- `npm run test:unit`: 366 passing