### PR TITLE
docs: enforce_admins true in branch protection command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,7 +108,7 @@ feature/issue-N-desc   ← short-lived; cut from the active release branch
    {
      "required_pull_request_reviews": {"required_approving_review_count": 0},
      "required_status_checks": null,
-     "enforce_admins": false,
+     "enforce_admins": true,
      "restrictions": null,
      "allow_force_pushes": false,
      "allow_deletions": false


### PR DESCRIPTION
## Summary
- Updates branch protection command in AGENTS.md to use `enforce_admins: true`
- Matches the protection now applied to `main` and `release-1.3.0`

## Testing
No code changes. `npm run test:unit`: 366 passing.