### PR TITLE
inject ST highlighting into Markdown fenced code blocks

### DIFF
--- a/manual-tests/markdown-injection/test.md
+++ b/manual-tests/markdown-injection/test.md
@@ -1,0 +1,57 @@
+# Markdown Injection Test
+
+Verify ST syntax highlighting inside fenced code blocks.
+
+## iecst fence (expect full ST highlighting)
+
+```iecst
+PROGRAM MainProgram
+VAR
+    counter : INT := 0;
+    limit   : INT := 100;
+    running : BOOL := TRUE;
+END_VAR
+
+(* Main control loop *)
+IF running AND (counter < limit) THEN
+    counter := counter + 1;
+ELSIF counter >= limit THEN
+    running := FALSE;
+END_IF;
+```
+
+## structured-text fence (expect full ST highlighting)
+
+```structured-text
+FUNCTION_BLOCK TimerFB
+VAR_INPUT
+    enable : BOOL;
+    preset : TIME := T#5s;
+END_VAR
+VAR_OUTPUT
+    done : BOOL;
+END_VAR
+VAR
+    elapsed : TIME;
+END_VAR
+
+(* TON-style timer logic *)
+IF enable THEN
+    elapsed := elapsed + T#100ms;
+    done := elapsed >= preset;
+ELSE
+    elapsed := T#0s;
+    done := FALSE;
+END_IF;
+END_FUNCTION_BLOCK
+```
+
+## st fence (expect NO ST highlighting — unregistered tag)
+
+```st
+VAR x : INT := 42; END_VAR
+```
+
+## Plain text (expect no impact)
+
+This paragraph is plain Markdown. No ST highlighting should bleed in here.

--- a/package.json
+++ b/package.json
@@ -65,6 +65,13 @@
         "language": "structured-text",
         "scopeName": "source.structured-text",
         "path": "./syntaxes/structured-text.tmLanguage.json"
+      },
+      {
+        "scopeName": "markdown.structured-text.codeblock",
+        "path": "./syntaxes/structured-text.markdown-injection.tmLanguage.json",
+        "injectTo": [
+          "text.html.markdown"
+        ]
       }
     ],
     "snippets": [

--- a/syntaxes/structured-text.markdown-injection.tmLanguage.json
+++ b/syntaxes/structured-text.markdown-injection.tmLanguage.json
@@ -1,0 +1,30 @@
+{
+    "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+    "name": "Structured Text (Markdown injection)",
+    "scopeName": "markdown.structured-text.codeblock",
+    "injectionSelector": "L:text.html.markdown",
+    "patterns": [
+        {
+            "include": "#fenced-st"
+        }
+    ],
+    "repository": {
+        "fenced-st": {
+            "begin": "(^|\\G)(\\s*)(```|~~~)\\s*(iecst|structured-text)\\s*$",
+            "beginCaptures": {
+                "3": { "name": "punctuation.definition.fenced.markdown" },
+                "4": { "name": "entity.name.function.fenced.markdown" }
+            },
+            "end": "(^|\\G)(\\2)(```|~~~)\\s*$",
+            "endCaptures": {
+                "3": { "name": "punctuation.definition.fenced.markdown" }
+            },
+            "contentName": "meta.embedded.block.structured-text",
+            "patterns": [
+                {
+                    "include": "source.structured-text"
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds injection grammar (`syntaxes/structured-text.markdown-injection.tmLanguage.json`) that embeds `source.structured-text` inside `` ```iecst `` and `` ```structured-text `` fenced blocks in Markdown files
- Registers the injection via `contributes.grammars` with `injectTo: ["text.html.markdown"]` in `package.json`
- Closes #85

## Testing

- `npm run test:unit`: 413 passing
- `npm run webpack-prod`: compiled clean (no errors)
- Manual: open `manual-tests/markdown-injection/test.md` and verify ST highlighting in `iecst`/`structured-text` fences, none in `st` fence or plain text