### PR TITLE
Named parameter syntax highlighting + false-positive diagnostic fixes (#94)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- Named parameters in FB/function calls (`Param :=`, `Param =>`) now scoped as `variable.parameter.st` in syntax highlighting (#94)
 - Signature Help for function and function block calls: triggers on `(` and `,`, supports manual trigger, highlights active parameter, includes standard + workspace signatures (#33)
 - Diagnostic error for assignment to CONSTANT-qualified variables (VAR CONSTANT, VAR_GLOBAL CONSTANT); paren-depth guard avoids false positives on named FB parameters (#60)
 - Diagnostic error for out-of-bounds array access with constant/literal indices; supports 1-D, multi-dimensional, zero-based, and negative-lower-bound arrays; variable indices ignored (#61)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - Diagnostic error for assignment to CONSTANT-qualified variables (VAR CONSTANT, VAR_GLOBAL CONSTANT); paren-depth guard avoids false positives on named FB parameters (#60)
 - Diagnostic error for out-of-bounds array access with constant/literal indices; supports 1-D, multi-dimensional, zero-based, and negative-lower-bound arrays; variable indices ignored (#61)
 
+### Fixed
+- Multi-line FB calls with closing `)` on its own line falsely flagged as "Unmatched closing parenthesis"; fixed with cross-line depth tracking
+- Output named parameters (`Param =>`) falsely flagged as undefined identifiers; `=>` pattern now excluded from identifier extraction
+
 ### Changed
 - Bump `@types/node` to `^25.0.0`, `glob` to `^13.0.0`; add `skipLibCheck` to tsconfig for TS 5.x / `@types/node` 25 compatibility (#124)
 - Standardized manual test fixture naming (removed `test_`/`test-` prefixes) and updated references

--- a/manual-tests/syntax/named-parameters.st
+++ b/manual-tests/syntax/named-parameters.st
@@ -1,0 +1,50 @@
+(* Manual test: named parameter highlighting in FB/function calls (#94)
+   Open this file in VS Code with the extension active.
+   Use "Developer: Inspect Editor Tokens and Scopes" (Ctrl+Shift+P) to
+   verify scope names on each token. *)
+
+PROGRAM TestNamedParams
+VAR
+    MyTimer   : TON;
+    MyCounter : CTU;
+    StartSig  : BOOL;
+    StopSig   : BOOL;
+    CountOut  : INT;
+    Result    : BOOL;
+    Val1      : INT;
+    Val2      : INT;
+    i         : INT;
+END_VAR
+
+(* --- EXPECTED: named params scoped as variable.parameter.st --- *)
+
+(* FB call with named input params: IN and PT should be variable.parameter.st *)
+MyTimer(IN := StartSig, PT := T#5s);
+
+(* FB call with named output param: Q should be variable.parameter.st, ET also *)
+MyTimer(IN := StartSig, PT := T#5s, Q => Result, ET => CountOut);
+
+(* Counter FB: CU, RESET, PV are variable.parameter.st; CV => is output *)
+MyCounter(CU := StartSig, RESET := StopSig, PV := 10, CV => CountOut);
+
+(* Function call with named params: Input1, Input2 are variable.parameter.st *)
+Result := MyFunc(Input1 := Val1, Input2 := Val2);
+
+(* Multi-line call: each param name on its own line should still be variable.parameter.st *)
+MyTimer(
+    IN := StartSig,
+    PT := T#10s
+);
+
+
+(* --- EXPECTED: regular assignments NOT scoped as variable.parameter.st --- *)
+
+(* Plain assignment: i should be a plain identifier, NOT variable.parameter.st *)
+i := 5;
+Result := TRUE;
+Val1 := Val2 + 1;
+
+(* Variable declaration assignment: also NOT variable.parameter.st *)
+(* (already shown in VAR block above) *)
+
+END_PROGRAM

--- a/manual-tests/syntax/named-parameters.st
+++ b/manual-tests/syntax/named-parameters.st
@@ -27,8 +27,8 @@ MyTimer(IN := StartSig, PT := T#5s, Q => Result, ET => CountOut);
 (* Counter FB: CU, RESET, PV are variable.parameter.st; CV => is output *)
 MyCounter(CU := StartSig, RESET := StopSig, PV := 10, CV => CountOut);
 
-(* Function call with named params: Input1, Input2 are variable.parameter.st *)
-Result := MyFunc(Input1 := Val1, Input2 := Val2);
+(* FB call with multiple named input params: CU, RESET, PV are variable.parameter.st *)
+MyCounter(CU := Val1, RESET := StopSig, PV := Val2);
 
 (* Multi-line call: each param name on its own line should still be variable.parameter.st *)
 MyTimer(

--- a/package-lock.json
+++ b/package-lock.json
@@ -701,9 +701,9 @@
       "license": "MIT"
     },
     "node_modules/@types/vscode": {
-      "version": "1.109.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.109.0.tgz",
-      "integrity": "sha512-0Pf95rnwEIwDbmXGC08r0B4TQhAbsHQ5UyTIgVgoieDe4cOnf92usuR5dEczb6bTKEp7ziZH4TV1TRGPPCExtw==",
+      "version": "1.110.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.110.0.tgz",
+      "integrity": "sha512-AGuxUEpU4F4mfuQjxPPaQVyuOMhs+VT/xRok1jiHVBubHK7lBRvCuOMZG0LKUwxncrPorJ5qq/uil3IdZBd5lA==",
       "dev": true,
       "license": "MIT"
     },

--- a/src/server/providers/diagnostics-provider.ts
+++ b/src/server/providers/diagnostics-provider.ts
@@ -844,6 +844,9 @@ function extractBodyIdentifiers(line: string): BodyToken[] {
         const afterToken = noStrings.slice(col + name.length).trimStart();
         if (afterToken.startsWith(':=')) continue;
 
+        // Skip named output parameter assigns in FB calls: "Q =>" — "Q" is a param name, not a variable
+        if (afterToken.startsWith('=>')) continue;
+
         tokens.push({ name, column: col });
     }
 

--- a/src/server/providers/diagnostics-provider.ts
+++ b/src/server/providers/diagnostics-provider.ts
@@ -9,7 +9,7 @@
  *  - Unmatched block keywords (PROGRAM/END_PROGRAM, FUNCTION/END_FUNCTION, etc.)
  *  - Unmatched VAR section keywords (VAR/END_VAR, VAR_INPUT/END_VAR, etc.)
  *  - Unclosed string literals (single and double quotes)
- *  - Unmatched parentheses within lines
+ *  - Unmatched parentheses (cross-line aware)
  *  - ELSE IF should be ELSIF (IEC 61131-3 §3.3.2)
  *  - Missing THEN after IF/ELSIF, missing DO after FOR/WHILE
  *
@@ -1712,39 +1712,50 @@ function checkUnclosedStrings(cleanLines: CleanLine[]): Diagnostic[] {
 function checkUnmatchedParentheses(cleanLines: CleanLine[]): Diagnostic[] {
     const diagnostics: Diagnostic[] = [];
 
+    let crossLineDepth = 0; // tracks open parens spanning multiple lines
+    let crossLineOpenLineIndex = -1;
+    let crossLineOpenCol = -1;
+
     for (const cl of cleanLines) {
         const lineNoStrings = stripStringLiterals(cl.text);
 
-        let depth = 0;
-        let firstOpenCol = -1;
+        let lineDepth = crossLineDepth;
+        let firstOpenCol = crossLineDepth > 0 ? crossLineOpenCol : -1;
 
         for (let i = 0; i < lineNoStrings.length; i++) {
             if (lineNoStrings[i] === '(') {
-                if (depth === 0) firstOpenCol = i;
-                depth++;
+                if (lineDepth === 0) {
+                    firstOpenCol = i;
+                    crossLineOpenLineIndex = cl.lineIndex;
+                    crossLineOpenCol = i;
+                }
+                lineDepth++;
             } else if (lineNoStrings[i] === ')') {
-                depth--;
-                if (depth < 0) {
+                lineDepth--;
+                if (lineDepth < 0) {
                     diagnostics.push(createDiagnostic(
                         cl.lineIndex, i, 1,
                         'Unmatched closing parenthesis',
                         DiagnosticSeverity.Error
                     ));
-                    depth = 0;
+                    lineDepth = 0;
                 }
             }
         }
 
+        crossLineDepth = lineDepth;
+
         // Unclosed parens on a statement line (ends with ;) — multi-line FB
         // calls don't end with ; so we only flag genuine errors here.
-        if (depth > 0 && cl.text.trimEnd().endsWith(';')) {
+        if (lineDepth > 0 && cl.text.trimEnd().endsWith(';')) {
             diagnostics.push(createDiagnostic(
                 cl.lineIndex,
                 firstOpenCol >= 0 ? firstOpenCol : 0,
                 1,
-                `Unmatched opening parenthesis (${depth} unclosed)`,
+                `Unmatched opening parenthesis (${lineDepth} unclosed)`,
                 DiagnosticSeverity.Error
             ));
+            crossLineDepth = 0;
         }
     }
 

--- a/src/test/unit/diagnostics-provider.unit.test.ts
+++ b/src/test/unit/diagnostics-provider.unit.test.ts
@@ -435,6 +435,20 @@ END_VAR
     x := 1;
 END_PROGRAM`);
         });
+
+        test('should not false-positive on multi-line FB call closing paren', () => {
+            assertNoDiagnostics(`
+PROGRAM Main
+VAR
+    MyTimer : TON;
+    StartSig : BOOL;
+END_VAR
+    MyTimer(
+        IN := StartSig,
+        PT := T#10s
+    );
+END_PROGRAM`);
+        });
     });
 
     suite('Case Insensitivity', () => {

--- a/src/test/unit/diagnostics-provider.unit.test.ts
+++ b/src/test/unit/diagnostics-provider.unit.test.ts
@@ -861,6 +861,22 @@ END_PROGRAM`);
             assert.strictEqual(undef.length, 0);
         });
 
+        test('should not flag output named parameters (=>) in FB calls', () => {
+            assertNoDiagnostics(`
+PROGRAM Main
+VAR
+    MyTimer   : TON;
+    MyCounter : CTU;
+    StartSig  : BOOL;
+    StopSig   : BOOL;
+    Result    : BOOL;
+    CountOut  : INT;
+END_VAR
+    MyTimer(IN := StartSig, PT := T#5s, Q => Result, ET => CountOut);
+    MyCounter(CU := StartSig, RESET := StopSig, PV := 10, CV => CountOut);
+END_PROGRAM`);
+        });
+
         test('should not flag identifiers inside CASE branches', () => {
             const diags = diagnoseWithSymbols(`
 PROGRAM Main

--- a/syntaxes/structured-text.tmLanguage.json
+++ b/syntaxes/structured-text.tmLanguage.json
@@ -21,7 +21,7 @@
             "include": "#data-types"
         },
         {
-            "include": "#functions"
+            "include": "#function-calls"
         }
     ],
     "repository": {
@@ -49,13 +49,60 @@
                 }
             ]
         },
-        "functions": {
+        "function-calls": {
+            "comment": "Function/FB call: name(...). Named params (Identifier := or Identifier =>) inside the arg list are scoped as variable.parameter.st.",
+            "begin": "\\b([A-Za-z_][A-Za-z0-9_]*)\\s*(\\()",
+            "beginCaptures": {
+                "1": { "name": "entity.name.function.st" },
+                "2": { "name": "punctuation.section.parens.begin.st" }
+            },
+            "end": "\\)",
+            "endCaptures": {
+                "0": { "name": "punctuation.section.parens.end.st" }
+            },
             "patterns": [
                 {
-                    "name": "entity.name.function.st",
-                    "match": "\\b[A-Za-z_][A-Za-z0-9_]*(?=\\s*\\()"
+                    "include": "#keywords"
+                },
+                {
+                    "include": "#strings"
+                },
+                {
+                    "include": "#comments"
+                },
+                {
+                    "include": "#numbers"
+                },
+                {
+                    "include": "#operators"
+                },
+                {
+                    "include": "#data-types"
+                },
+                {
+                    "include": "#named-parameter-input"
+                },
+                {
+                    "include": "#named-parameter-output"
+                },
+                {
+                    "include": "#function-calls"
                 }
             ]
+        },
+        "named-parameter-input": {
+            "comment": "Input named parameter: ParamName := value",
+            "match": "\\b([A-Za-z_][A-Za-z0-9_]*)\\b(?=\\s*:=)",
+            "captures": {
+                "1": { "name": "variable.parameter.st" }
+            }
+        },
+        "named-parameter-output": {
+            "comment": "Output named parameter: ParamName => variable",
+            "match": "\\b([A-Za-z_][A-Za-z0-9_]*)\\b(?=\\s*=>)",
+            "captures": {
+                "1": { "name": "variable.parameter.st" }
+            }
         },
         "strings": {
             "patterns": [


### PR DESCRIPTION
## Summary

- Scope named call parameters (`Param :=`, `Param =>`) as `variable.parameter.st` in syntax highlighting (#94)
- Fix false-positive "Unmatched closing parenthesis" on multi-line FB calls (cross-line depth tracking)
- Fix false-positive undefined identifier on output named parameters (`Param =>`)

Closes #94