### PR TITLE
Strip issue references from non-CHANGELOG files

### DIFF
--- a/.github/ISSUE_TEMPLATE/technical-debt.yml
+++ b/.github/ISSUE_TEMPLATE/technical-debt.yml
@@ -7,7 +7,7 @@ body:
     attributes:
       label: Context
       description: Why does this need doing? What triggered it?
-      placeholder: "Dead code audit after parser rewrite (#41) found significant unused code.\n\nNote: do not prefix the issue title with category labels — use labels instead."
+      placeholder: "Dead code audit after parser rewrite found significant unused code.\n\nNote: do not prefix the issue title with category labels — use labels instead."
     validations:
       required: true
 

--- a/docs/releases/v1.2.5.md
+++ b/docs/releases/v1.2.5.md
@@ -8,12 +8,12 @@ Version 1.2.5 fixes several critical bugs from the initial LSP launch, including
 
 ## What's Fixed
 
-- **Duplicate completions**: Removed redundant completion provider from extension client (#37)
-- **Test environment**: npm test works in clean environments (#38)
-- **Extension packaging**: iec61131-definitions/ now accessible in packaged .vsix (#39)
-- **Workspace portability**: Removed hardcoded directory name lookup (#40)
-- **Case sensitivity**: Symbol lookup normalized per IEC 61131-3 (#42)
-- **Memory leak**: Index cleanup on file close, debounced change handling (#43)
+- **Duplicate completions**: Removed redundant completion provider from extension client
+- **Test environment**: npm test works in clean environments
+- **Extension packaging**: iec61131-definitions/ now accessible in packaged .vsix
+- **Workspace portability**: Removed hardcoded directory name lookup
+- **Case sensitivity**: Symbol lookup normalized per IEC 61131-3
+- **Memory leak**: Index cleanup on file close, debounced change handling
 
 ## What's Changed
 

--- a/docs/releases/v1.3.0.md
+++ b/docs/releases/v1.3.0.md
@@ -8,31 +8,31 @@ Version 1.3.0 is a major feature release adding full LSP-based diagnostics, code
 
 ## What's Added
 
-- **Rich hover tooltips** for all standard function blocks: parameter tables, behavior descriptions, usage examples (#22)
-- **Advanced diagnostics**: missing semicolons, duplicate declarations, undefined variables, unused variables, type mismatches (#6)
-- **Semantic analysis** powered by AST parser for deeper code inspection (#6)
-- **Quick fixes**: insert semicolon, remove duplicate declaration, remove unused variable (#6)
-- **Levenshtein fuzzy matching** for "did you mean?" suggestions on undefined identifiers (#6)
-- **Code formatting** (`Shift+Alt+F` / `Ctrl+Shift+I` on Linux): keyword casing, indentation, operator spacing, VAR block alignment, trailing whitespace removal (#29)
-- **Format Selection** for partial document formatting (#29)
-- **Configurable formatting settings**: keywordCase, insertSpacesAroundOperators, alignVarDeclarations, trimTrailingWhitespace, insertFinalNewline (#29)
-- **Rename Symbol** (F2): rename variables, functions, FBs, programs with IEC 61131-3 validation and comment awareness (#28)
-- **Code actions**: auto-insert missing END blocks, close unclosed strings, fix unmatched parentheses (#26)
-- **Real-time diagnostics** in Problems panel: unmatched blocks, unclosed strings, unmatched parentheses (#27)
-- **AST parser rewrite** with multi-line statement accumulator (#41)
-- **QA checklist** covering all 14 feature categories with manual test fixtures (#75)
+- **Rich hover tooltips** for all standard function blocks: parameter tables, behavior descriptions, usage examples
+- **Advanced diagnostics**: missing semicolons, duplicate declarations, undefined variables, unused variables, type mismatches
+- **Semantic analysis** powered by AST parser for deeper code inspection
+- **Quick fixes**: insert semicolon, remove duplicate declaration, remove unused variable
+- **Levenshtein fuzzy matching** for "did you mean?" suggestions on undefined identifiers
+- **Code formatting** (`Shift+Alt+F` / `Ctrl+Shift+I` on Linux): keyword casing, indentation, operator spacing, VAR block alignment, trailing whitespace removal
+- **Format Selection** for partial document formatting
+- **Configurable formatting settings**: keywordCase, insertSpacesAroundOperators, alignVarDeclarations, trimTrailingWhitespace, insertFinalNewline
+- **Rename Symbol** (F2): rename variables, functions, FBs, programs with IEC 61131-3 validation and comment awareness
+- **Code actions**: auto-insert missing END blocks, close unclosed strings, fix unmatched parentheses
+- **Real-time diagnostics** in Problems panel: unmatched blocks, unclosed strings, unmatched parentheses
+- **AST parser rewrite** with multi-line statement accumulator
+- **QA checklist** covering all 14 feature categories with manual test fixtures
 - 366 unit tests covering all providers
 
 ## What's Changed
 
-- License changed from BUSL-1.1 to MIT (#78)
-- Extracted `getExtensionPath` into `extension-path.ts` for testability (#44)
-- Updated all npm dependencies (TypeScript 4.9→5.9, webpack 5.99→5.105, node types 16→20) (#50)
+- License changed from BUSL-1.1 to MIT
+- Extracted `getExtensionPath` into `extension-path.ts` for testability
+- Updated all npm dependencies (TypeScript 4.9→5.9, webpack 5.99→5.105, node types 16→20)
 - Removed legacy parser (`parser.ts`) and its tests
 
 ## What's Fixed
 
-- Parser regex fails on multi-line variable declarations (#41)
+- Parser regex fails on multi-line variable declarations
 - Verbose console.log in definition provider polluting output
 
 ## Installation

--- a/manual-tests/code-actions/missing-declaration.st
+++ b/manual-tests/code-actions/missing-declaration.st
@@ -1,4 +1,4 @@
-// Manual test: Missing Variable Declaration Detection & Auto-Fix (#32)
+// Manual test: Missing Variable Declaration Detection & Auto-Fix
 //
 // How to test:
 //  1. Open this file in VS Code with ControlForge ST extension active.

--- a/manual-tests/diagnostics/array-bounds.st
+++ b/manual-tests/diagnostics/array-bounds.st
@@ -1,4 +1,4 @@
-(* Manual QA: array bounds checking for constant indices (#61) *)
+(* Manual QA: array bounds checking for constant indices *)
 (* Open this file in VS Code. Verify red squiggles appear ONLY on lines marked  *)
 (* "EXPECT ERROR" and that no errors appear on lines marked "OK".               *)
 (* Check the Problems panel (Ctrl+Shift+M) for full messages.                   *)

--- a/manual-tests/diagnostics/constant-assignment.st
+++ b/manual-tests/diagnostics/constant-assignment.st
@@ -1,4 +1,4 @@
-(* Manual QA: constant assignment detection (#60) *)
+(* Manual QA: constant assignment detection *)
 (* Open this file in VS Code. Verify red squiggles appear ONLY on the lines   *)
 (* marked "EXPECT ERROR" and that no errors appear on lines marked "OK".       *)
 

--- a/manual-tests/diagnostics/for-loop-bounds.st
+++ b/manual-tests/diagnostics/for-loop-bounds.st
@@ -1,4 +1,4 @@
-(* Manual QA: FOR loop bounds validation (#62) *)
+(* Manual QA: FOR loop bounds validation *)
 (* Open this file in VS Code. Verify squiggles appear ONLY on lines marked     *)
 (* "EXPECT <SEVERITY>" and that no squiggles appear on lines marked "OK".      *)
 (* Check the Problems panel (Ctrl+Shift+M) for full messages.                   *)

--- a/manual-tests/hover/fb-hover-tooltips.st
+++ b/manual-tests/hover/fb-hover-tooltips.st
@@ -1,4 +1,4 @@
-(* Manual test: FB hover tooltips (#22)
+(* Manual test: FB hover tooltips
    Hover over type names and instance names to verify rich tooltips
    with parameter tables, behavior descriptions, and usage examples. *)
 

--- a/manual-tests/rename/rename-symbols.st
+++ b/manual-tests/rename/rename-symbols.st
@@ -1,4 +1,4 @@
-(* Manual test: Rename Symbol (#28)
+(* Manual test: Rename Symbol
    Use F2 or right-click > Rename Symbol to test rename across this file.
    Verify both successful renames and rejection of invalid names. *)
 

--- a/manual-tests/snippets/snippets-test.st
+++ b/manual-tests/snippets/snippets-test.st
@@ -1,4 +1,4 @@
-(* Snippet Manual Tests — IEC 61131-3 Code Snippets (#80) *)
+(* Snippet Manual Tests — IEC 61131-3 Code Snippets *)
 (*
    HOW TO TEST:
    In a .st file, type the prefix and press Tab (or select from IntelliSense).

--- a/manual-tests/syntax/named-parameters.st
+++ b/manual-tests/syntax/named-parameters.st
@@ -1,4 +1,4 @@
-(* Manual test: named parameter highlighting in FB/function calls (#94)
+(* Manual test: named parameter highlighting in FB/function calls
    Open this file in VS Code with the extension active.
    Use "Developer: Inspect Editor Tokens and Scopes" (Ctrl+Shift+P) to
    verify scope names on each token. *)


### PR DESCRIPTION
## Summary
- Issue refs belong only in CHANGELOG.md; stripped (#N) from manual-tests/, docs/releases/, and the issue template placeholder
- No functional changes

## Testing
- `npm run test:unit`: 499 passing

## Post-merge
- [ ] Close linked issue(s)