### PR TITLE
Document issue-ref rule in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,3 +146,5 @@ Title format: `vX.Y.0 - Short Theme` (e.g. `v1.3.0 - Stability & Core LSP`). The
 ## Changelog
 
 Follow [Keep a Changelog](https://keepachangelog.com/) with Fixed/Added/Changed/Removed sections. No severity labels. Concise, no implementation details. Unreleased work goes under `[Unreleased]`.
+
+Issue references (`(#N)`) are allowed **only** in `CHANGELOG.md` and `docs/releases/` documents, and **only** on `### Fixed` entries (bug fixes). Do not add issue refs to Added/Changed/Removed entries, source code, comments, manual test fixtures, or any other file.


### PR DESCRIPTION
## Summary
- Adds the issue-reference placement rule to `## Changelog` section of AGENTS.md
- `(#N)` refs allowed only in CHANGELOG.md and docs/releases/, and only on `### Fixed` entries

## Testing
- No code changes; docs-only
- npm run test:unit: 531 passing