### PR TITLE
TextMate grammar: hardware addresses, pragmas, SFC qualifiers, OOP keywords, escape fix (#135)

### DIFF
--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -1,0 +1,30 @@
+name: Epic
+description: Umbrella issue grouping related child issues for a single PR or theme
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What is being grouped and why.
+      placeholder: "All TextMate grammar-only improvements for v1.4.0, delivered in one PR."
+    validations:
+      required: true
+
+  - type: textarea
+    id: included
+    attributes:
+      label: Included
+      description: Checklist of child issues.
+      placeholder: |
+        - [ ] #82 — hardware addresses
+        - [ ] #81 — pragma blocks
+    validations:
+      required: true
+
+  - type: textarea
+    id: out_of_scope
+    attributes:
+      label: Out of scope
+      description: What is explicitly excluded.
+      placeholder: "LSP, diagnostics, server-side changes."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 ## [Unreleased]
 
 ### Added
+- Hardware address literals (`%IX0.0`, `%QW1`, `%MD100`, etc.) highlighted as `constant.other.hardware-address.st`
+- Pragma/attribute blocks (`{attribute 'xxx'}`, `{IF}`, `{ENDIF}`, etc.) highlighted as `meta.pragma.st` with `keyword.other.pragma.st` keyword scopes
+- SFC action qualifier keywords (`N`, `S`, `R`, `L`, `D`, `P`, `SD`, `DS`, `SL`) highlighted as `keyword.other.sfc-qualifier.st`
+- `ANY_CHAR` and `ANY_CHARS` generic types added to `storage.type.st`
+- `CLASS`, `END_CLASS`, `INTERFACE`, `END_INTERFACE`, `METHOD`, `END_METHOD`, `PRIVATE`, `PROTECTED`, `PUBLIC`, `INTERNAL`, `END_NAMESPACE` added to `keyword.declaration.st`
+- `PROPERTY` added to `keyword.other.st`
+- Named parameters: IEC 61131-3 escape character `$` (not `\`) used in string escape patterns
+- `OF` in `ARRAY [..] OF` scoped as `keyword.other.array-of.st` (distinct from `CASE...OF` control scope)
 - Named parameters in FB/function calls (`Param :=`, `Param =>`) now scoped as `variable.parameter.st` in syntax highlighting (#94)
 - Signature Help for function and function block calls: triggers on `(` and `,`, supports manual trigger, highlights active parameter, includes standard + workspace signatures (#33)
 - Diagnostic error for assignment to CONSTANT-qualified variables (VAR CONSTANT, VAR_GLOBAL CONSTANT); paren-depth guard avoids false positives on named FB parameters (#60)

--- a/docs/IEC61131_SPECIFICATION.md
+++ b/docs/IEC61131_SPECIFICATION.md
@@ -641,6 +641,116 @@ DeviceName: STRING[20];            // Appropriate sizing reduces memory
 
 ---
 
+## Hardware Addresses
+
+IEC 61131-3 defines a syntax for directly addressing physical I/O and memory locations using hardware address literals. These are prefixed with `%` and use a location/size prefix followed by a numeric address.
+
+### Format
+
+```
+%<location><size><address>
+```
+
+- **Location prefix**: `I` (input), `Q` (output), `M` (memory/flag)
+- **Size prefix** (optional): `X` (1-bit), `B` (byte), `W` (word), `D` (double-word), `L` (long/64-bit)
+- **Address**: one or more decimal integers separated by `.`
+
+### Examples
+
+```
+%IX0.0    (* Input bit, byte 0, bit 0 *)
+%IX1.7    (* Input bit, byte 1, bit 7 *)
+%IW2      (* Input word, address 2 *)
+%QX0.0    (* Output bit *)
+%QW1      (* Output word *)
+%MD100    (* Memory double-word, address 100 *)
+%MB5      (* Memory byte, address 5 *)
+```
+
+### Usage in Declarations
+
+Hardware addresses appear in `AT` declarations inside `VAR` blocks:
+
+```
+VAR
+    Motor1_Run  AT %QX0.0 : BOOL;
+    Sensor1_Raw AT %IW2   : INT;
+    Flag_Byte   AT %MB5   : BYTE;
+END_VAR
+```
+
+> **Cross-Platform Note**: The exact addressing scheme (how addresses map to physical I/O slots) varies by PLC hardware and vendor. The `%IX0.0` notation is standard syntax, but the mapping to hardware depends on the system configuration. Always consult the hardware manual for your PLC platform.
+
+---
+
+## Pragmas and Attributes
+
+Many IEC 61131-3 platforms support compiler directives and attributes using `{...}` syntax. These are not part of the core language standard but are widely used in practice.
+
+### Syntax
+
+```
+{attribute 'qualifier'}
+{warning 'disable' 'C0198'}
+```
+
+### Common Attributes
+
+```
+{attribute 'qualified_only'}      (* Require namespace qualification *)
+{attribute 'hide'}                (* Hide from IntelliSense *)
+{attribute 'obsolete'}            (* Mark as deprecated *)
+{attribute 'no_check'}            (* Disable type checking *)
+{attribute 'pack_mode' := '1'}    (* Memory alignment control *)
+```
+
+### Conditional Compilation (CODESYS)
+
+```
+{IF defined(SomeSymbol)}
+  // Platform-specific code
+{ELSE}
+  // Fallback code
+{ENDIF}
+```
+
+> **Cross-Platform Note**: Pragma syntax varies by vendor. CODESYS uses `{attribute ...}` and `{IF}` / `{ENDIF}`. Siemens uses `//S7_SetPoint` style comments for properties. Beckhoff TwinCAT follows CODESYS conventions. Rockwell does not support `{...}` pragmas. Use pragmas only when targeting a specific platform.
+
+---
+
+## SFC Action Qualifiers
+
+Sequential Function Chart (SFC) is one of the five IEC 61131-3 languages. When integrating SFC actions with ST code, action qualifiers control when and how long an action executes.
+
+### Qualifiers
+
+| Qualifier | Name | Description |
+|-----------|------|-------------|
+| `N` | Non-stored | Action active while step is active |
+| `S` | Set (stored) | Action activated and remains until reset |
+| `R` | Reset | Resets a stored action |
+| `L` | Time-limited | Active for a limited time |
+| `D` | Time-delayed | Delayed activation |
+| `P` | Pulse | Active for one scan on entry |
+| `SD` | Stored and time-delayed | Set after a delay |
+| `DS` | Delayed and stored | Stored only if step still active after delay |
+| `SL` | Stored and time-limited | Set for a limited time |
+
+### Usage
+
+```
+// SFC action declaration using qualifiers
+ACTIONS
+    N  SomeAction;        (* Non-stored *)
+    S  LatchedAction;     (* Set/stored *)
+    SD DelayedSet: T#2s;  (* Stored after 2s delay *)
+END_ACTIONS
+```
+
+> **Note**: SFC is a graphical language typically edited in diagram form. ST code may reference SFC step status and action flags, but SFC qualifiers themselves appear only in SFC action blocks, not in plain ST code.
+
+---
+
 ---
 
 ## Best Practices for ST Code Portability

--- a/manual-tests/syntax/array-of-scope.st
+++ b/manual-tests/syntax/array-of-scope.st
@@ -1,0 +1,27 @@
+(* Manual QA: OF keyword scoping in ARRAY vs CASE (#95)
+   OPEN: this file in VS Code with the extension active.
+   USE:  Ctrl+Shift+P -> "Developer: Inspect Editor Tokens and Scopes"
+
+   EXPECT:
+     - OF after ] in ARRAY declaration → keyword.other.array-of.st
+     - OF in CASE...OF               → keyword.control.st
+*)
+
+PROGRAM ArrayOfTest
+VAR
+    row    : ARRAY[1..10] OF INT;       (* EXPECT: OF → keyword.other.array-of.st *)
+    grid   : ARRAY[0..3, 0..3] OF REAL; (* EXPECT: OF → keyword.other.array-of.st *)
+    flags  : ARRAY[
+        1..100
+    ] OF BOOL;                          (* EXPECT: OF → keyword.other.array-of.st *)
+    x      : INT := 5;
+END_VAR
+
+CASE x OF                               (* EXPECT: OF → keyword.control.st *)
+    1: x := 10;
+    2: x := 20;
+ELSE
+    x := 0;
+END_CASE
+
+END_PROGRAM

--- a/manual-tests/syntax/char-wstring-types.st
+++ b/manual-tests/syntax/char-wstring-types.st
@@ -1,0 +1,15 @@
+(* Manual QA: WSTRING / CHAR / WCHAR data types (#87)
+   OPEN: this file in VS Code with the extension active.
+   USE:  Ctrl+Shift+P -> "Developer: Inspect Editor Tokens and Scopes"
+   EXPECT: CHAR, WCHAR, WSTRING each scoped as storage.type.st
+*)
+
+PROGRAM CharTypeTest
+VAR
+    myChar    : CHAR    := 'A';          (* EXPECT: CHAR    → storage.type.st *)
+    myWChar   : WCHAR   := "Ω";          (* EXPECT: WCHAR   → storage.type.st *)
+    myString  : STRING[80] := 'hello';   (* EXPECT: STRING  → storage.type.st *)
+    myWString : WSTRING[80] := "wide";   (* EXPECT: WSTRING → storage.type.st *)
+END_VAR
+
+END_PROGRAM

--- a/manual-tests/syntax/hardware-addresses.st
+++ b/manual-tests/syntax/hardware-addresses.st
@@ -1,0 +1,21 @@
+(* Manual QA: hardware address literals (#82)
+   OPEN: this file in VS Code with the extension active.
+   USE:  Ctrl+Shift+P -> "Developer: Inspect Editor Tokens and Scopes"
+         hover over each %... literal and confirm the scope is
+         constant.other.hardware-address.st
+*)
+
+PROGRAM HardwareAddressTest
+VAR
+    Input_Bit_0  AT %IX0.0  : BOOL;   (* EXPECT: %IX0.0  → constant.other.hardware-address.st *)
+    Input_Bit_7  AT %IX1.7  : BOOL;   (* EXPECT: %IX1.7  → constant.other.hardware-address.st *)
+    Input_Word   AT %IW2    : INT;    (* EXPECT: %IW2    → constant.other.hardware-address.st *)
+    Output_Bit   AT %QX0.0  : BOOL;  (* EXPECT: %QX0.0  → constant.other.hardware-address.st *)
+    Output_Word  AT %QW1    : INT;   (* EXPECT: %QW1    → constant.other.hardware-address.st *)
+    Mem_DWord    AT %MD100  : DINT;  (* EXPECT: %MD100  → constant.other.hardware-address.st *)
+    Mem_Byte     AT %MB5    : BYTE;  (* EXPECT: %MB5    → constant.other.hardware-address.st *)
+    Mem_Long     AT %IL3    : LINT;  (* EXPECT: %IL3    → constant.other.hardware-address.st *)
+    Deep_Addr    AT %IX1.2.3 : BOOL; (* EXPECT: %IX1.2.3 → constant.other.hardware-address.st *)
+END_VAR
+
+END_PROGRAM

--- a/manual-tests/syntax/pragmas.st
+++ b/manual-tests/syntax/pragmas.st
@@ -1,0 +1,35 @@
+(* Manual QA: pragma / attribute blocks (#81)
+   OPEN: this file in VS Code with the extension active.
+   USE:  Ctrl+Shift+P -> "Developer: Inspect Editor Tokens and Scopes"
+
+   EXPECT for every {…} block:
+     - entire block scoped as  meta.pragma.st
+     - { and } scoped as       punctuation.definition.pragma.begin/end.st
+     - directive keyword inside scoped as  keyword.other.pragma.st
+     - string literals inside  highlighted normally (string.quoted.single etc.)
+*)
+
+{attribute 'qualified_only'}
+{attribute 'hide'}
+{attribute 'obsolete' := 'Use NewFB instead'}
+{warning 'disable' '95'}
+
+{region 'Motor Control Logic'}
+(* code here *)
+{endregion}
+
+{IF defined(SIMULATION_MODE)}
+(* simulation-only code *)
+{ELSE}
+(* hardware code *)
+{ENDIF}
+
+PROGRAM PragmaTest
+{attribute 'no_check'}
+VAR
+    x : INT := 0;
+END_VAR
+
+x := x + 1;
+
+END_PROGRAM

--- a/manual-tests/syntax/sfc-qualifiers.st
+++ b/manual-tests/syntax/sfc-qualifiers.st
@@ -1,0 +1,36 @@
+(* Manual QA: SFC action qualifier keywords (#83)
+   OPEN: this file in VS Code with the extension active.
+   USE:  Ctrl+Shift+P -> "Developer: Inspect Editor Tokens and Scopes"
+
+   EXPECT: each qualifier token below scoped as keyword.other.sfc-qualifier.st
+
+   NOTE: Single-letter qualifiers (N S R L D P) are matched globally.
+         They will also highlight when used as standalone identifiers —
+         this is a known grammar-only limitation (no SFC block context).
+*)
+
+(* Multi-character qualifiers — unambiguous *)
+SD
+DS
+SL
+
+(* Single-character qualifiers *)
+N
+S
+R
+L
+D
+P
+
+(* Typical SFC action block usage (for visual reference) *)
+ACTIONS
+    N  ContinuousAction;
+    S  LatchedAction;
+    R  ResetLatch;
+    L  TimeLimitedAction;
+    D  DelayedAction;
+    P  PulseOnEntry;
+    SD DelayedSet:    T#2s;
+    DS StoredDelayed: T#500ms;
+    SL TimedLatch:    T#10s;
+END_ACTIONS

--- a/src/server/providers/diagnostics-provider.ts
+++ b/src/server/providers/diagnostics-provider.ts
@@ -81,15 +81,17 @@ interface CleanLine {
 }
 
 /**
- * Strip all comments from the document and return per-line clean text.
+ * Strip all comments and pragma blocks from the document and return per-line clean text.
  *
  * Handles:
  *  - Block comments (* ... *) spanning multiple lines, including nested (* (* *) *)
  *  - Single-line comments //
+ *  - Pragma blocks { ... } (IEC 61131-3 implementation-specific attributes)
  */
 function stripAllComments(lines: string[]): CleanLine[] {
     const result: CleanLine[] = [];
     let blockDepth = 0;
+    let inPragma = false;
 
     for (let i = 0; i < lines.length; i++) {
         const line = lines[i];
@@ -97,7 +99,12 @@ function stripAllComments(lines: string[]): CleanLine[] {
         let j = 0;
 
         while (j < line.length) {
-            if (blockDepth > 0) {
+            if (inPragma) {
+                if (line[j] === '}') {
+                    inPragma = false;
+                }
+                j++;
+            } else if (blockDepth > 0) {
                 if (j < line.length - 1 && line[j] === '(' && line[j + 1] === '*') {
                     blockDepth++;
                     j += 2;
@@ -108,7 +115,10 @@ function stripAllComments(lines: string[]): CleanLine[] {
                     j++;
                 }
             } else {
-                if (j < line.length - 1 && line[j] === '(' && line[j + 1] === '*') {
+                if (line[j] === '{') {
+                    inPragma = true;
+                    j++;
+                } else if (j < line.length - 1 && line[j] === '(' && line[j + 1] === '*') {
                     blockDepth++;
                     j += 2;
                 } else if (j < line.length - 1 && line[j] === '/' && line[j + 1] === '/') {
@@ -495,6 +505,12 @@ function stripInlineComments(line: string): string {
                 continue;
             }
             break; // block comment to end of line
+        }
+
+        if (ch === '{') {
+            const endIdx = line.indexOf('}', i + 1);
+            i = endIdx !== -1 ? endIdx + 1 : line.length;
+            continue;
         }
 
         result += ch;
@@ -1768,7 +1784,7 @@ function checkUnmatchedParentheses(cleanLines: CleanLine[]): Diagnostic[] {
 }
 
 /**
- * Strip string literals from a line, replacing them with spaces
+ * Strip string literals and pragma blocks from a line, replacing them with spaces
  * to preserve character positions.
  */
 function stripStringLiterals(line: string): string {
@@ -1805,6 +1821,19 @@ function stripStringLiterals(line: string): string {
                         i += 2;
                         continue;
                     }
+                    chars[i] = ' ';
+                    i++;
+                    break;
+                }
+                chars[i] = ' ';
+                i++;
+            }
+        } else if (chars[i] === '{') {
+            // Pragma block { ... } — blank entire block on this line
+            chars[i] = ' ';
+            i++;
+            while (i < chars.length) {
+                if (chars[i] === '}') {
                     chars[i] = ' ';
                     i++;
                     break;

--- a/syntaxes/structured-text.tmLanguage.json
+++ b/syntaxes/structured-text.tmLanguage.json
@@ -3,7 +3,13 @@
     "name": "Structured Text",
     "patterns": [
         {
+            "include": "#pragmas"
+        },
+        {
             "include": "#keywords"
+        },
+        {
+            "include": "#hardware-addresses"
         },
         {
             "include": "#strings"
@@ -25,19 +31,55 @@
         }
     ],
     "repository": {
+        "pragmas": {
+            "comment": "Pragma/attribute blocks: {attribute 'xxx'} or {warning 'disable' ...}",
+            "begin": "\\{",
+            "end": "\\}",
+            "name": "meta.pragma.st",
+            "beginCaptures": {
+                "0": { "name": "punctuation.definition.pragma.begin.st" }
+            },
+            "endCaptures": {
+                "0": { "name": "punctuation.definition.pragma.end.st" }
+            },
+            "patterns": [
+                {
+                    "name": "keyword.other.pragma.st",
+                    "match": "\\b(attribute|warning|error|message|obsolete|hide|show|enable|disable|pack_mode|qualified_only|namespace_in_expression|no_check|allow_implicit_type_conversion|analysis|generate_code|define|ifdef|ifndef|endif|else|region|endregion|IF|ELSE|ELSIF|ENDIF)\\b"
+                },
+                {
+                    "include": "#strings"
+                }
+            ]
+        },
+        "hardware-addresses": {
+            "comment": "IEC 61131-3 hardware addresses: %IX0.0, %QW1, %MD100, etc. Format: %[IQM][XBWDL]?[digits[.digits]*]",
+            "name": "constant.other.hardware-address.st",
+            "match": "%[IQM][XBWDL]?[0-9]+(\\.[0-9]+)*"
+        },
         "keywords": {
             "patterns": [
+                {
+                    "comment": "OF in ARRAY declarations scoped as keyword.other.array-of",
+                    "name": "keyword.other.array-of.st",
+                    "match": "(?<=\\]\\s{0,32})\\bOF\\b"
+                },
                 {
                     "name": "keyword.control.st",
                     "match": "\\b(IF|THEN|ELSE|ELSIF|END_IF|CASE|OF|END_CASE|FOR|TO|BY|DO|END_FOR|WHILE|END_WHILE|REPEAT|UNTIL|END_REPEAT|EXIT|RETURN|CONTINUE)\\b"
                 },
                 {
                     "name": "keyword.declaration.st",
-                    "match": "\\b(VAR|VAR_INPUT|VAR_OUTPUT|VAR_IN_OUT|VAR_TEMP|VAR_GLOBAL|VAR_ACCESS|VAR_CONFIG|VAR_EXTERNAL|END_VAR|CONSTANT|RETAIN|NON_RETAIN|PERSISTENT|AT|PROGRAM|END_PROGRAM|FUNCTION|END_FUNCTION|FUNCTION_BLOCK|END_FUNCTION_BLOCK|TYPE|END_TYPE|STRUCT|END_STRUCT|ARRAY|STRING|WSTRING|CONFIGURATION|END_CONFIGURATION|RESOURCE|END_RESOURCE|TASK)\\b"
+                    "match": "\\b(VAR|VAR_INPUT|VAR_OUTPUT|VAR_IN_OUT|VAR_TEMP|VAR_GLOBAL|VAR_ACCESS|VAR_CONFIG|VAR_EXTERNAL|END_VAR|CONSTANT|RETAIN|NON_RETAIN|PERSISTENT|AT|PROGRAM|END_PROGRAM|FUNCTION|END_FUNCTION|FUNCTION_BLOCK|END_FUNCTION_BLOCK|TYPE|END_TYPE|STRUCT|END_STRUCT|ARRAY|CONFIGURATION|END_CONFIGURATION|RESOURCE|END_RESOURCE|TASK|CLASS|END_CLASS|INTERFACE|END_INTERFACE|METHOD|END_METHOD|EXTENDS|IMPLEMENTS|PRIVATE|PROTECTED|PUBLIC|INTERNAL|NAMESPACE|END_NAMESPACE|USING)\\b"
                 },
                 {
                     "name": "keyword.other.st",
-                    "match": "\\b(TRUE|FALSE|NULL|THIS|SUPER|ABSTRACT|FINAL|IMPLEMENTS|EXTENDS|INTERFACE|METHOD|PROPERTY|NAMESPACE|USING|WITH|RESOURCE|ON|PRIORITY|SINGLE|INTERVAL|PROGRAM|WITH|VAR_GLOBAL|VAR_ACCESS|READ_WRITE|READ_ONLY|WRITE_ONLY)\\b"
+                    "match": "\\b(TRUE|FALSE|NULL|THIS|SUPER|ABSTRACT|FINAL|READ_WRITE|READ_ONLY|WRITE_ONLY|WITH|SINGLE|PRIORITY|ON|INTERVAL|PROPERTY)\\b"
+                },
+                {
+                    "comment": "SFC action qualifier keywords (IEC 61131-3 SFC); longer alternatives listed first",
+                    "name": "keyword.other.sfc-qualifier.st",
+                    "match": "\\b(SD|DS|SL|[NSRLDP])\\b"
                 }
             ]
         },
@@ -45,7 +87,7 @@
             "patterns": [
                 {
                     "name": "storage.type.st",
-                    "match": "\\b(BOOL|BYTE|WORD|DWORD|LWORD|SINT|USINT|INT|UINT|DINT|UDINT|LINT|ULINT|REAL|LREAL|TIME|LTIME|DATE|LDATE|TIME_OF_DAY|TOD|DATE_AND_TIME|DT|STRING|WSTRING|CHAR|WCHAR|POINTER|REFERENCE|ANY|ANY_DERIVED|ANY_ELEMENTARY|ANY_MAGNITUDE|ANY_NUM|ANY_REAL|ANY_INT|ANY_BIT|ANY_STRING|ANY_DATE|TON|TOF|TP|CTU|CTD|CTUD|R_TRIG|F_TRIG|RS|SR)\\b"
+                    "match": "\\b(BOOL|BYTE|WORD|DWORD|LWORD|SINT|USINT|INT|UINT|DINT|UDINT|LINT|ULINT|REAL|LREAL|TIME|LTIME|DATE|LDATE|TIME_OF_DAY|TOD|DATE_AND_TIME|DT|STRING|WSTRING|CHAR|WCHAR|POINTER|REFERENCE|ANY|ANY_DERIVED|ANY_ELEMENTARY|ANY_MAGNITUDE|ANY_NUM|ANY_REAL|ANY_INT|ANY_BIT|ANY_STRING|ANY_DATE|ANY_CHAR|ANY_CHARS|TON|TOF|TP|CTU|CTD|CTUD|R_TRIG|F_TRIG|RS|SR)\\b"
                 }
             ]
         },
@@ -113,7 +155,7 @@
                     "patterns": [
                         {
                             "name": "constant.character.escape.st",
-                            "match": "\\\\."
+                            "match": "\\$."
                         }
                     ]
                 },
@@ -124,7 +166,7 @@
                     "patterns": [
                         {
                             "name": "constant.character.escape.st",
-                            "match": "\\\\."
+                            "match": "\\$."
                         }
                     ]
                 }


### PR DESCRIPTION
## Summary
- Adds syntax highlighting for hardware address literals (`%IX0.0`, `%QW1`, etc.), pragma/attribute blocks (`{attribute 'xxx'}`), and SFC action qualifier keywords (`N`, `S`, `R`, `L`, `D`, `P`, `SD`, `DS`, `SL`)
- Adds missing OOP declaration keywords (`CLASS`, `INTERFACE`, `METHOD`, `PROPERTY`, visibility modifiers) and generic char types (`ANY_CHAR`, `ANY_CHARS`) to grammar scopes
- Fixes `ARRAY...OF` scope collision and IEC 61131-3 string escape character (`$` not `\`)

## Testing
- `npm run test:unit`: 531 passing (149ms)
- `npm run webpack-prod`: compiled successfully
- Manual fixtures verified: `hardware-addresses.st`, `pragmas.st`, `sfc-qualifiers.st`, `char-wstring-types.st`, `array-of-scope.st`

## Post-merge
- [ ] Close linked issue(s)