### PR TITLE
chore: release v1.4.0 version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-03-15
+
 ### Added
 - ST syntax highlighting injected into `<Declaration>`, `<ST>`, `<Implementation>`, and `<Interface>` XML elements in TwinCAT/CoDeSys export files (plain content and CDATA-wrapped)
 - Hardware address literals (`%IX0.0`, `%QW1`, `%MD100`, etc.) highlighted as `constant.other.hardware-address.st`

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "controlforge-structured-text",
   "displayName": "ControlForge Structured Text",
   "description": "Professional Structured Text (IEC 61131-3) IDE with real-time diagnostics, code actions & quick fixes, function block IntelliSense, and smart code completion for PLC programming",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "author": "Michael Distel",
   "publisher": "ControlForgeSystems",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Bump version to 1.4.0 in package.json
- Move CHANGELOG [Unreleased] entries to [1.4.0] - 2026-03-15

## Testing
- npm run test:unit: 541 passing
- npm run webpack-prod: passing