### PR TITLE
chore: sync main into release-1.4.0 (conflict resolution)

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,12 @@
         "path": "./syntaxes/structured-text.code-snippets"
       }
     ],
+    "snippets": [
+      {
+        "language": "structured-text",
+        "path": "./syntaxes/structured-text.code-snippets"
+      }
+    ],
     "commands": [
       {
         "command": "controlforge-structured-text.validateSyntax",


### PR DESCRIPTION
## Summary
- Merge main into release-1.4.0 to resolve conflicts before release PR
- Conflicts in diagnostics-provider.ts, code-action-provider.ts, diagnostics unit tests, and snippets-test.st resolved in favour of release-1.4.0 (release branch has newer/more complete versions)
- Picks up snippets (#120), Node 24 config (#119), FB call validation (#118) from main

## Testing
- npm run test:unit: 541 passing