### PR TITLE
Add controlforge.dev and Marketplace badges to README, improve Installation section (#145)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+- Website and VS Code Marketplace badge links at the top of README
+- Improved Installation section: direct marketplace link + Quick Open install command
+
 ## [1.4.0] - 2026-03-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # ControlForge Structured Text
 
+[![Website](https://img.shields.io/badge/controlforge.dev-0066b8?style=flat&logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0id2hpdGUiIGQ9Ik0xMiAyQTEwIDEwIDAgMCAwIDIgMTJhMTAgMTAgMCAwIDAgMTAgMTAgMTAgMTAgMCAwIDAgMTAtMTBBMTAgMTAgMCAwIDAgMTIgMm0tMSAxNy45M1Y0LjA3YzIuODMuNDggNSAyLjk0IDUgNS45M3MtMi4xNyA1LjQ1LTUgNS45M3oiLz48L3N2Zz4=)](https://controlforge.dev)
 [![Visual Studio Marketplace Version](https://img.shields.io/visual-studio-marketplace/v/ControlForgeSystems.controlforge-structured-text?label=VS%20Marketplace&color=0066b8)](https://marketplace.visualstudio.com/items?itemName=ControlForgeSystems.controlforge-structured-text)
 [![Visual Studio Marketplace Installs](https://img.shields.io/visual-studio-marketplace/i/ControlForgeSystems.controlforge-structured-text)](https://marketplace.visualstudio.com/items?itemName=ControlForgeSystems.controlforge-structured-text)
 
@@ -24,10 +25,18 @@ Professional **Structured Text (IEC 61131-3)** development environment for **PLC
 ## Getting Started
 
 ### Installation
+
+**Option 1 — Marketplace (recommended):**
+[Install from VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=ControlForgeSystems.controlforge-structured-text)
+
+**Option 2 — Inside VS Code:**
 1. Open **Visual Studio Code**
-2. Go to **Extensions** (`Ctrl+Shift+X`)
-3. Search for **"ControlForge Structured Text"**
+2. Open Extensions (`Ctrl+Shift+X`)
+3. Search **"ControlForge Structured Text"**
 4. Click **Install**
+
+**Option 3 — Quick Open:**
+Press `Ctrl+P`, paste `ext install ControlForgeSystems.controlforge-structured-text`, press `Enter`.
 
 ### Commands
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "controlforge-structured-text",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "controlforge-structured-text",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "vscode-languageclient": "^9.0.1",
@@ -677,9 +677,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.4.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.4.0.tgz",
-      "integrity": "sha512-9wLpoeWuBlcbBpOY3XmzSTG3oscB6xjBEEtn+pYXTfhyXhIxC5FsBer2KTopBlvKEiW9l13po9fq+SJY/5lkhw==",
+      "version": "25.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
+      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary

- Add website (`controlforge.dev`) and VS Code Marketplace badge/links at top of README, above all existing content
- Improve Installation section: three options — direct Marketplace link, Extensions panel, Quick Open command
- Bump `@types/node` 25.4.0 → 25.5.0 (minor, non-breaking)

## Testing

- `npm run test:unit`: 541 passing
- `npm run webpack-prod`: compiled with 0 errors (1 pre-existing warning)
- Changes are documentation-only; no runtime code modified