### PR TITLE
Add author link to README and package.json metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 - Website and VS Code Marketplace badge links at the top of README
 - Improved Installation section: direct marketplace link + Quick Open install command
+- Author link (michaeldistel.com) in the README Support section and package.json metadata
 
 ## [1.4.0] - 2026-03-15
 

--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ END_PROGRAM
 ## Support & Feedback
 
 - **Website**: [controlforge.dev](https://controlforge.dev/)
+- **Author**: [Michael Distel](https://michaeldistel.com)
 - **Issues**: [GitHub Issues](https://github.com/ControlForge-Systems/controlforge-structured-text/issues)
 - **Discussions**: [GitHub Discussions](https://github.com/ControlForge-Systems/controlforge-structured-text/discussions)
 - **Rate & Review**: [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=ControlForgeSystems.controlforge-structured-text)

--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "displayName": "ControlForge Structured Text",
   "description": "Professional Structured Text (IEC 61131-3) IDE with real-time diagnostics, code actions & quick fixes, function block IntelliSense, and smart code completion for PLC programming",
   "version": "1.4.0",
-  "author": "Michael Distel",
+  "author": {
+    "name": "Michael Distel",
+    "url": "https://michaeldistel.com"
+  },
   "publisher": "ControlForgeSystems",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Adds an Author line to the README Support & Feedback section linking to michaeldistel.com (renders on the VS Code Marketplace overview page), and expands the package.json author field to carry the same URL. CHANGELOG updated under [Unreleased].