### PR TITLE
Release v1.4.1 - author link hotfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [1.4.1] - 2026-08-13
+
+### Added
+- Author link (michaeldistel.com) in the README Support section and package.json metadata
+
 ## [1.4.0] - 2026-03-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ END_PROGRAM
 ## Support & Feedback
 
 - **Website**: [controlforge.dev](https://controlforge.dev/)
+- **Author**: [Michael Distel](https://michaeldistel.com)
 - **Issues**: [GitHub Issues](https://github.com/ControlForge-Systems/controlforge-structured-text/issues)
 - **Discussions**: [GitHub Discussions](https://github.com/ControlForge-Systems/controlforge-structured-text/discussions)
 - **Rate & Review**: [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=ControlForgeSystems.controlforge-structured-text)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "controlforge-structured-text",
-  "version": "1.3.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "controlforge-structured-text",
-      "version": "1.3.0",
+      "version": "1.4.1",
       "license": "MIT",
       "dependencies": {
         "vscode-languageclient": "^9.0.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "controlforge-structured-text",
   "displayName": "ControlForge Structured Text",
   "description": "Professional Structured Text (IEC 61131-3) IDE with real-time diagnostics, code actions & quick fixes, function block IntelliSense, and smart code completion for PLC programming",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "author": {
     "name": "Michael Distel",
     "url": "https://michaeldistel.com"
@@ -90,18 +90,6 @@
         "path": "./syntaxes/structured-text.code-snippets"
       }
     ],
-    "snippets": [
-      {
-        "language": "structured-text",
-        "path": "./syntaxes/structured-text.code-snippets"
-      }
-    ],
-    "snippets": [
-      {
-        "language": "structured-text",
-        "path": "./syntaxes/structured-text.code-snippets"
-      }
-    ],
     "commands": [
       {
         "command": "controlforge-structured-text.validateSyntax",
@@ -121,7 +109,11 @@
       "properties": {
         "structured-text.format.keywordCase": {
           "type": "string",
-          "enum": ["upper", "lower", "preserve"],
+          "enum": [
+            "upper",
+            "lower",
+            "preserve"
+          ],
           "default": "upper",
           "description": "Keyword casing preference: UPPER, lower, or preserve existing case"
         },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "displayName": "ControlForge Structured Text",
   "description": "Professional Structured Text (IEC 61131-3) IDE with real-time diagnostics, code actions & quick fixes, function block IntelliSense, and smart code completion for PLC programming",
   "version": "1.4.0",
-  "author": "Michael Distel",
+  "author": {
+    "name": "Michael Distel",
+    "url": "https://michaeldistel.com"
+  },
   "publisher": "ControlForgeSystems",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary
- Hotfix release 1.4.1 off main: author link (michaeldistel.com) in the README Support & Feedback section and package.json author metadata (cherry-picked from release-1.5.0, where it merged in #150)
- Version bumped 1.4.0 -> 1.4.1, CHANGELOG gains a [1.4.1] section; npm's manifest rewrite also removed two identical duplicate "snippets" keys

## Testing
- Pre-commit validation passed on both commits
- package.json parses clean; author object and README link verified