### PR TITLE
Sync CHANGELOG with the 1.4.1 hotfix release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 ### Added
 - Website and VS Code Marketplace badge links at the top of README
 - Improved Installation section: direct marketplace link + Quick Open install command
+
+## [1.4.1] - 2026-08-13
+
+### Added
 - Author link (michaeldistel.com) in the README Support section and package.json metadata
 
 ## [1.4.0] - 2026-03-15


### PR DESCRIPTION
## Summary
- Moves the author link entry from [Unreleased] to a [1.4.1] - 2026-08-13 section, matching the hotfix shipped from main (#151)

## Testing
- Documentation-only change