### PR TITLE
Exclude internal agent instructions and repo tooling from the VSIX

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -41,3 +41,11 @@ publish-extension.sh
 # LICENSE
 # icon.png
 # images/ (for screenshots)
+
+# Internal agent/dev instructions and repo tooling - never ship in the VSIX
+.claude/**
+tasks/**
+CLAUDE.md
+AGENTS.md
+.github/**
+.nvmrc


### PR DESCRIPTION
## Summary
- Adds .claude/**, tasks/**, CLAUDE.md, AGENTS.md, .github/** and .nvmrc to .vscodeignore - the 1.4.1 publish shipped AGENTS.md and .github/, and a build from this branch would also ship CLAUDE.md plus 30 files under .claude/
- Directory entries use /** because bare directory names do not match contents in vsce ignore globs

## Testing
- npx vsce ls after the change: 25 files, none of the excluded paths present; package now contains only runtime and user-facing files